### PR TITLE
Added Embedding requests + Fixed metadata and others retrieval classes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ url = "^2.4"
 async-trait = "^0.1"
 futures = "^0.3.1"
 futures-util = "^0.3"
-
-
-dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "gemini-rust"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Rust client for Google Gemini API"
 license = "MIT"
 repository = "https://github.com/flachesis/gemini-rust"
 readme = "README.md"
-keywords = ["gemini", "google", "ai", "client"]
+keywords = ["gemini", "embed", "google", "ai", "client"]
 categories = ["api-bindings"]
 
 [dependencies]
@@ -19,3 +19,6 @@ url = "^2.4"
 async-trait = "^0.1"
 futures = "^0.3.1"
 futures-util = "^0.3"
+
+
+dotenv = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gemini-rust"
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 description = "Rust client for Google Gemini API"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+### Text Embedding
+
+```rust
+use gemini_rust::{Gemini, TaskType};
+use tokio;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {    
+    let api_key = std::env::var("GEMINI_API_KEY")?;
+
+    // Create client with the default model (gemini-2.0-flash)
+    let client = Gemini::with_model(api_key, "models/text-embedding-004".to_string());
+
+    println!("Sending embedding request to Gemini API...");
+
+    // Simple text embedding
+    let response = client
+        .embed_content()
+        .with_text("Hello, this is my text to embed")
+        .with_task_type(TaskType::RetrievalDocument)
+        .execute()
+        .await?;
+
+    println!("Response: {:?}", response.embedding.values);
+
+    Ok(())
+}
+```
+
 ## Documentation
 
 For more examples and detailed documentation, see [docs.rs](https://docs.rs/gemini-rust).

--- a/examples/batch_embedding.rs
+++ b/examples/batch_embedding.rs
@@ -1,0 +1,28 @@
+use gemini_rust::{Gemini, TaskType};
+use dotenv::dotenv;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {    
+    dotenv().ok(); // Load environment variables from .env file
+    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
+
+    // Create client with the default model (gemini-2.0-flash)
+    let client = Gemini::with_model(api_key, "models/text-embedding-004".to_string());
+
+    println!("Sending batch embedding request to Gemini API...");
+
+    // Simple text embedding
+    let response = client
+        .embed_content()
+        .with_chunks(vec!["Hello", "World", "Test embedding 3"])
+        .with_task_type(TaskType::RetrievalDocument)
+        .execute_batch()
+        .await?;
+
+    println!("Response: ");
+    for (i, e) in response.embeddings.iter().enumerate() {
+        println!("|{}|: {:?}\n", i, e.values);
+    }
+
+    Ok(())
+}

--- a/examples/batch_embedding.rs
+++ b/examples/batch_embedding.rs
@@ -1,10 +1,8 @@
 use gemini_rust::{Gemini, TaskType};
-use dotenv::dotenv;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {    
-    dotenv().ok(); // Load environment variables from .env file
-    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)
     let client = Gemini::with_model(api_key, "models/text-embedding-004".to_string());

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,10 +1,8 @@
 use gemini_rust::{Gemini, TaskType};
-use dotenv::dotenv;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {    
-    dotenv().ok(); // Load environment variables from .env file
-    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
+    let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)
     let client = Gemini::with_model(api_key, "models/text-embedding-004".to_string());

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,0 +1,25 @@
+use gemini_rust::{Gemini, TaskType};
+use dotenv::dotenv;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {    
+    dotenv().ok(); // Load environment variables from .env file
+    let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
+
+    // Create client with the default model (gemini-2.0-flash)
+    let client = Gemini::with_model(api_key, "models/text-embedding-004".to_string());
+
+    println!("Sending embedding request to Gemini API...");
+
+    // Simple text embedding
+    let response = client
+        .embed_content()
+        .with_text("Hello")
+        .with_task_type(TaskType::RetrievalDocument)
+        .execute()
+        .await?;
+
+    println!("Response: {:?}", response.embedding.values);
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,14 +1,12 @@
 use crate::{
-    models::{
-        Content, FunctionCallingConfig, FunctionCallingMode, GenerateContentRequest,
-        GenerationConfig, GenerationResponse, Message, Role, ToolConfig,
-    },
-    tools::{FunctionDeclaration, Tool},
-    Error, Result,
+    content_builder::ContentBuilder, embed_builder::EmbedBuilder, models::{
+        BatchContentEmbeddingResponse, BatchEmbedContentsRequest, ContentEmbeddingResponse, EmbedContentRequest, GenerateContentRequest, GenerationResponse
+    }, Error, Result
 };
 use futures::stream::Stream;
 use futures_util::StreamExt;
 use reqwest::Client;
+use serde_json::Value;
 use std::pin::Pin;
 use std::sync::Arc;
 use url::Url;
@@ -16,266 +14,11 @@ use url::Url;
 const BASE_URL: &str = "https://generativelanguage.googleapis.com/v1beta/";
 const DEFAULT_MODEL: &str = "models/gemini-2.0-flash";
 
-/// Builder for content generation requests
-pub struct ContentBuilder {
-    client: Arc<GeminiClient>,
-    pub contents: Vec<Content>,
-    generation_config: Option<GenerationConfig>,
-    tools: Option<Vec<Tool>>,
-    tool_config: Option<ToolConfig>,
-    system_instruction: Option<Content>,
-}
-
-impl ContentBuilder {
-    /// Create a new content builder
-    fn new(client: Arc<GeminiClient>) -> Self {
-        Self {
-            client,
-            contents: Vec::new(),
-            generation_config: None,
-            tools: None,
-            tool_config: None,
-            system_instruction: None,
-        }
-    }
-
-    /// Add a system prompt to the request
-    pub fn with_system_prompt(self, text: impl Into<String>) -> Self {
-        // Create a Content with text parts specifically for system_instruction field
-        self.with_system_instruction(text)
-    }
-
-    /// Set the system instruction directly (matching the API format in the curl example)
-    pub fn with_system_instruction(mut self, text: impl Into<String>) -> Self {
-        // Create a Content with text parts specifically for system_instruction field
-        let content = Content::text(text);
-        self.system_instruction = Some(content);
-        self
-    }
-
-    /// Add a user message to the request
-    pub fn with_user_message(mut self, text: impl Into<String>) -> Self {
-        let message = Message::user(text);
-        let content = message.content;
-        self.contents.push(content);
-        self
-    }
-
-    /// Add a model message to the request
-    pub fn with_model_message(mut self, text: impl Into<String>) -> Self {
-        let message = Message::model(text);
-        let content = message.content;
-        self.contents.push(content);
-        self
-    }
-
-    /// Add a function response to the request using a JSON value
-    pub fn with_function_response(
-        mut self,
-        name: impl Into<String>,
-        response: serde_json::Value,
-    ) -> Self {
-        let content = Content::function_response_json(name, response).with_role(Role::User);
-        self.contents.push(content);
-        self
-    }
-
-    /// Add a function response to the request using a JSON string
-    pub fn with_function_response_str(
-        mut self,
-        name: impl Into<String>,
-        response: impl Into<String>,
-    ) -> std::result::Result<Self, serde_json::Error> {
-        let response_str = response.into();
-        let json = serde_json::from_str(&response_str)?;
-        let content = Content::function_response_json(name, json).with_role(Role::User);
-        self.contents.push(content);
-        Ok(self)
-    }
-
-    /// Add a message to the request
-    pub fn with_message(mut self, message: Message) -> Self {
-        let content = message.content.clone();
-        match &content.role {
-            Some(role) => {
-                let role_clone = role.clone();
-                self.contents.push(content.with_role(role_clone));
-            }
-            None => {
-                self.contents.push(content.with_role(message.role));
-            }
-        }
-        self
-    }
-
-    /// Add multiple messages to the request
-    pub fn with_messages(mut self, messages: impl IntoIterator<Item = Message>) -> Self {
-        for message in messages {
-            self = self.with_message(message);
-        }
-        self
-    }
-
-    /// Set the generation config for the request
-    pub fn with_generation_config(mut self, config: GenerationConfig) -> Self {
-        self.generation_config = Some(config);
-        self
-    }
-
-    /// Set the temperature for the request
-    pub fn with_temperature(mut self, temperature: f32) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.temperature = Some(temperature);
-        }
-        self
-    }
-
-    /// Set the top-p value for the request
-    pub fn with_top_p(mut self, top_p: f32) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.top_p = Some(top_p);
-        }
-        self
-    }
-
-    /// Set the top-k value for the request
-    pub fn with_top_k(mut self, top_k: i32) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.top_k = Some(top_k);
-        }
-        self
-    }
-
-    /// Set the maximum output tokens for the request
-    pub fn with_max_output_tokens(mut self, max_output_tokens: i32) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.max_output_tokens = Some(max_output_tokens);
-        }
-        self
-    }
-
-    /// Set the candidate count for the request
-    pub fn with_candidate_count(mut self, candidate_count: i32) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.candidate_count = Some(candidate_count);
-        }
-        self
-    }
-
-    /// Set the stop sequences for the request
-    pub fn with_stop_sequences(mut self, stop_sequences: Vec<String>) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.stop_sequences = Some(stop_sequences);
-        }
-        self
-    }
-
-    /// Set the response mime type for the request
-    pub fn with_response_mime_type(mut self, mime_type: impl Into<String>) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.response_mime_type = Some(mime_type.into());
-        }
-        self
-    }
-
-    /// Set the response schema for structured output
-    pub fn with_response_schema(mut self, schema: serde_json::Value) -> Self {
-        if self.generation_config.is_none() {
-            self.generation_config = Some(GenerationConfig::default());
-        }
-        if let Some(config) = &mut self.generation_config {
-            config.response_schema = Some(schema);
-        }
-        self
-    }
-
-    /// Add a tool to the request
-    pub fn with_tool(mut self, tool: Tool) -> Self {
-        if self.tools.is_none() {
-            self.tools = Some(Vec::new());
-        }
-        if let Some(tools) = &mut self.tools {
-            tools.push(tool);
-        }
-        self
-    }
-
-    /// Add a function declaration as a tool
-    pub fn with_function(mut self, function: FunctionDeclaration) -> Self {
-        let tool = Tool::new(function);
-        self = self.with_tool(tool);
-        self
-    }
-
-    /// Set the function calling mode for the request
-    pub fn with_function_calling_mode(mut self, mode: FunctionCallingMode) -> Self {
-        if self.tool_config.is_none() {
-            self.tool_config = Some(ToolConfig {
-                function_calling_config: Some(FunctionCallingConfig { mode }),
-            });
-        } else if let Some(tool_config) = &mut self.tool_config {
-            tool_config.function_calling_config = Some(FunctionCallingConfig { mode });
-        }
-        self
-    }
-
-    /// Execute the request
-    pub async fn execute(self) -> Result<GenerationResponse> {
-        let request = GenerateContentRequest {
-            contents: self.contents,
-            generation_config: self.generation_config,
-            safety_settings: None,
-            tools: self.tools,
-            tool_config: self.tool_config,
-            system_instruction: self.system_instruction,
-        };
-
-        self.client.generate_content_raw(request).await
-    }
-
-    /// Execute the request with streaming
-    pub async fn execute_stream(
-        self,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<GenerationResponse>> + Send>>> {
-        let request = GenerateContentRequest {
-            contents: self.contents,
-            generation_config: self.generation_config,
-            safety_settings: None,
-            tools: self.tools,
-            tool_config: self.tool_config,
-            system_instruction: self.system_instruction,
-        };
-
-        self.client.generate_content_stream(request).await
-    }
-}
-
 /// Internal client for making requests to the Gemini API
-struct GeminiClient {
+pub(crate) struct GeminiClient {
     http_client: Client,
     api_key: String,
-    model: String,
+    pub model: String,
 }
 
 impl GeminiClient {
@@ -289,14 +32,14 @@ impl GeminiClient {
     }
 
     /// Generate content
-    async fn generate_content_raw(
+    pub(crate) async fn generate_content_raw(
         &self,
         request: GenerateContentRequest,
     ) -> Result<GenerationResponse> {
         let url = self.build_url("generateContent")?;
 
         let response = self.http_client.post(url).json(&request).send().await?;
-
+        
         let status = response.status();
         if !status.is_success() {
             let error_text = response.text().await?;
@@ -307,11 +50,12 @@ impl GeminiClient {
         }
 
         let response = response.json().await?;
+
         Ok(response)
     }
 
     /// Generate content with streaming
-    async fn generate_content_stream(
+    pub(crate) async fn generate_content_stream(
         &self,
         request: GenerateContentRequest,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<GenerationResponse>> + Send>>> {
@@ -358,6 +102,47 @@ impl GeminiClient {
         Ok(Box::pin(stream))
     }
 
+    /// Embed content
+    pub(crate) async fn embed_content(
+        &self,
+        request: EmbedContentRequest,
+    ) -> Result<ContentEmbeddingResponse> {
+        let value = self.embed(request, "embedContent").await?;
+        let response = serde_json::from_value::<ContentEmbeddingResponse>(value)?;
+
+        Ok(response)
+    }
+
+    /// Batch Embed content
+    pub(crate) async fn embed_content_batch(
+        &self,
+        request: BatchEmbedContentsRequest,
+    ) -> Result<BatchContentEmbeddingResponse> {
+        let value = self.embed(request, "batchEmbedContents").await?;
+        let response = serde_json::from_value::<BatchContentEmbeddingResponse>(value)?;
+
+        Ok(response)
+    }
+
+    /// Embed content base function
+    async fn embed<T: serde::Serialize>(&self, request: T, endpoint: &str) -> Result<Value> {
+        let url = self.build_url(endpoint)?;
+    
+        let response = self.http_client.post(url).json(&request).send().await?;
+    
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await?;
+            return Err(Error::ApiError {
+                status_code: status.as_u16(),
+                message: error_text,
+            });
+        }
+
+        let response = response.json().await?;
+        Ok(response)
+    }
+    
     /// Build a URL for the API
     fn build_url(&self, endpoint: &str) -> Result<Url> {
         // All Gemini API endpoints now use the format with colon:
@@ -398,5 +183,10 @@ impl Gemini {
     /// Start building a content generation request
     pub fn generate_content(&self) -> ContentBuilder {
         ContentBuilder::new(self.client.clone())
+    }
+
+    /// Start building a content generation request
+    pub fn embed_content(&self) -> EmbedBuilder {
+        EmbedBuilder::new(self.client.clone())
     }
 }

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -1,0 +1,262 @@
+use std::{pin::Pin, sync::Arc};
+
+use futures::Stream;
+
+use crate::{client::GeminiClient, models::{FunctionCallingConfig, GenerateContentRequest, ToolConfig}, Content, FunctionCallingMode, FunctionDeclaration, GenerationConfig, GenerationResponse, Message, Role, Tool, Result};
+
+
+
+/// Builder for content generation requests
+pub struct ContentBuilder {
+    client: Arc<GeminiClient>,
+    pub contents: Vec<Content>,
+    generation_config: Option<GenerationConfig>,
+    tools: Option<Vec<Tool>>,
+    tool_config: Option<ToolConfig>,
+    system_instruction: Option<Content>,
+}
+
+impl ContentBuilder {
+    /// Create a new content builder
+    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+        Self {
+            client,
+            contents: Vec::new(),
+            generation_config: None,
+            tools: None,
+            tool_config: None,
+            system_instruction: None,
+        }
+    }
+
+    /// Add a system prompt to the request
+    pub fn with_system_prompt(self, text: impl Into<String>) -> Self {
+        // Create a Content with text parts specifically for system_instruction field
+        self.with_system_instruction(text)
+    }
+
+    /// Set the system instruction directly (matching the API format in the curl example)
+    pub fn with_system_instruction(mut self, text: impl Into<String>) -> Self {
+        // Create a Content with text parts specifically for system_instruction field
+        let content = Content::text(text);
+        self.system_instruction = Some(content);
+        self
+    }
+
+    /// Add a user message to the request
+    pub fn with_user_message(mut self, text: impl Into<String>) -> Self {
+        let message = Message::user(text);
+        let content = message.content;
+        self.contents.push(content);
+        self
+    }
+
+    /// Add a model message to the request
+    pub fn with_model_message(mut self, text: impl Into<String>) -> Self {
+        let message = Message::model(text);
+        let content = message.content;
+        self.contents.push(content);
+        self
+    }
+
+    /// Add a function response to the request using a JSON value
+    pub fn with_function_response(
+        mut self,
+        name: impl Into<String>,
+        response: serde_json::Value,
+    ) -> Self {
+        let content = Content::function_response_json(name, response).with_role(Role::User);
+        self.contents.push(content);
+        self
+    }
+
+    /// Add a function response to the request using a JSON string
+    pub fn with_function_response_str(
+        mut self,
+        name: impl Into<String>,
+        response: impl Into<String>,
+    ) -> std::result::Result<Self, serde_json::Error> {
+        let response_str = response.into();
+        let json = serde_json::from_str(&response_str)?;
+        let content = Content::function_response_json(name, json).with_role(Role::User);
+        self.contents.push(content);
+        Ok(self)
+    }
+
+    /// Add a message to the request
+    pub fn with_message(mut self, message: Message) -> Self {
+        let content = message.content.clone();
+        match &content.role {
+            Some(role) => {
+                let role_clone = role.clone();
+                self.contents.push(content.with_role(role_clone));
+            }
+            None => {
+                self.contents.push(content.with_role(message.role));
+            }
+        }
+        self
+    }
+
+    /// Add multiple messages to the request
+    pub fn with_messages(mut self, messages: impl IntoIterator<Item = Message>) -> Self {
+        for message in messages {
+            self = self.with_message(message);
+        }
+        self
+    }
+
+    /// Set the generation config for the request
+    pub fn with_generation_config(mut self, config: GenerationConfig) -> Self {
+        self.generation_config = Some(config);
+        self
+    }
+
+    /// Set the temperature for the request
+    pub fn with_temperature(mut self, temperature: f32) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.temperature = Some(temperature);
+        }
+        self
+    }
+
+    /// Set the top-p value for the request
+    pub fn with_top_p(mut self, top_p: f32) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.top_p = Some(top_p);
+        }
+        self
+    }
+
+    /// Set the top-k value for the request
+    pub fn with_top_k(mut self, top_k: i32) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.top_k = Some(top_k);
+        }
+        self
+    }
+
+    /// Set the maximum output tokens for the request
+    pub fn with_max_output_tokens(mut self, max_output_tokens: i32) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.max_output_tokens = Some(max_output_tokens);
+        }
+        self
+    }
+
+    /// Set the candidate count for the request
+    pub fn with_candidate_count(mut self, candidate_count: i32) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.candidate_count = Some(candidate_count);
+        }
+        self
+    }
+
+    /// Set the stop sequences for the request
+    pub fn with_stop_sequences(mut self, stop_sequences: Vec<String>) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.stop_sequences = Some(stop_sequences);
+        }
+        self
+    }
+
+    /// Set the response mime type for the request
+    pub fn with_response_mime_type(mut self, mime_type: impl Into<String>) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.response_mime_type = Some(mime_type.into());
+        }
+        self
+    }
+
+    /// Set the response schema for structured output
+    pub fn with_response_schema(mut self, schema: serde_json::Value) -> Self {
+        if self.generation_config.is_none() {
+            self.generation_config = Some(GenerationConfig::default());
+        }
+        if let Some(config) = &mut self.generation_config {
+            config.response_schema = Some(schema);
+        }
+        self
+    }
+
+    /// Add a tool to the request
+    pub fn with_tool(mut self, tool: Tool) -> Self {
+        if self.tools.is_none() {
+            self.tools = Some(Vec::new());
+        }
+        if let Some(tools) = &mut self.tools {
+            tools.push(tool);
+        }
+        self
+    }
+
+    /// Add a function declaration as a tool
+    pub fn with_function(mut self, function: FunctionDeclaration) -> Self {
+        let tool = Tool::new(function);
+        self = self.with_tool(tool);
+        self
+    }
+
+    /// Set the function calling mode for the request
+    pub fn with_function_calling_mode(mut self, mode: FunctionCallingMode) -> Self {
+        if self.tool_config.is_none() {
+            self.tool_config = Some(ToolConfig {
+                function_calling_config: Some(FunctionCallingConfig { mode }),
+            });
+        } else if let Some(tool_config) = &mut self.tool_config {
+            tool_config.function_calling_config = Some(FunctionCallingConfig { mode });
+        }
+        self
+    }
+
+    /// Execute the request
+    pub async fn execute(self) -> Result<GenerationResponse> {
+        let request = GenerateContentRequest {
+            contents: self.contents,
+            generation_config: self.generation_config,
+            safety_settings: None,
+            tools: self.tools,
+            tool_config: self.tool_config,
+            system_instruction: self.system_instruction,
+        };
+
+        self.client.generate_content_raw(request).await
+    }
+
+    /// Execute the request with streaming
+    pub async fn execute_stream(
+        self,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<GenerationResponse>> + Send>>> {
+        let request = GenerateContentRequest {
+            contents: self.contents,
+            generation_config: self.generation_config,
+            safety_settings: None,
+            tools: self.tools,
+            tool_config: self.tool_config,
+            system_instruction: self.system_instruction,
+        };
+
+        self.client.generate_content_stream(request).await
+    }
+}

--- a/src/embed_builder.rs
+++ b/src/embed_builder.rs
@@ -1,0 +1,96 @@
+use std::sync::Arc;
+
+use crate::{client::GeminiClient, models::{BatchContentEmbeddingResponse, BatchEmbedContentsRequest, ContentEmbeddingResponse, EmbedContentRequest, TaskType}, Content, Message, Result};
+
+
+
+/// Builder for embed generation requests
+pub struct EmbedBuilder {
+    client: Arc<GeminiClient>,
+    contents: Vec<Content>,
+    task_type: Option<TaskType>,
+    title: Option<String>,
+    output_dimensionality: Option<i32>,
+}
+
+impl EmbedBuilder {
+    /// Create a new embed builder
+    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+        Self {
+            client,
+            contents: Vec::new(),
+            task_type: None,
+            title: None,
+            output_dimensionality: None,
+        }
+    }
+
+    /// Add a vec of text to embed to the request
+    pub fn with_text(mut self, text: impl Into<String>) -> Self {
+        let message = Message::embed(text);
+        self.contents.push(message.content);
+        self
+    }
+
+    /// Add a vec of chunks to batch embed to the request
+    pub fn with_chunks(mut self, chunks: Vec<impl Into<String>>) -> Self {
+        //for each chunks 
+        for chunk in chunks {
+            let message = Message::embed(chunk);
+            self.contents.push(message.content);
+        }
+        self
+    }
+
+    /// Specify embedding task type 
+    pub fn with_task_type(mut self, task_type: TaskType) -> Self {
+        self.task_type = Some(task_type);
+        self
+    }
+
+    /// Specify document title
+    /// Supported by newer models since 2024 only !!
+    pub fn with_title(mut self, title: String) -> Self {
+        self.title = Some(title);
+        self
+    }
+    
+    /// Specify output_dimensionality. If set, excessive values in the output embedding are truncated from the end
+    /// Supported by newer models since 2024 only !!
+    pub fn with_output_dimensionality(mut self, title: String) -> Self {
+        self.title = Some(title);
+        self
+    }
+
+    /// Execute the request
+    pub async fn execute(self) -> Result<ContentEmbeddingResponse> {
+        let request = EmbedContentRequest {
+            model: self.client.model.clone(),
+            content: self.contents.first().expect("No content set").clone(),
+            task_type: self.task_type,
+            title: self.title,
+            output_dimensionality: self.output_dimensionality,
+        };
+
+        self.client.embed_content(request).await
+    }
+
+    /// Execute the request
+    pub async fn execute_batch(self) -> Result<BatchContentEmbeddingResponse> {
+        let mut batch_request = BatchEmbedContentsRequest { requests: Vec::new() };
+
+        for content in self.contents {
+            let request = EmbedContentRequest {
+                model: self.client.model.clone(),
+                content: content.clone(),
+                task_type: self.task_type.clone(),
+                title: self.title.clone(),
+                output_dimensionality: self.output_dimensionality,
+            };
+            batch_request.requests.push(request);
+        }
+
+        self.client.embed_content_batch(batch_request).await
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! A Rust client library for Google's Gemini 2.0 API.
 
 mod client;
+mod content_builder;
+mod embed_builder;
 mod error;
 mod models;
 mod tools;
@@ -11,7 +13,7 @@ pub use client::Gemini;
 pub use error::Error;
 pub use models::{
     Candidate, CitationMetadata, Content, FunctionCallingMode, GenerationConfig,
-    GenerationResponse, Message, Part, Role, SafetyRating,
+    GenerationResponse, Message, Part, Role, SafetyRating, TaskType
 };
 pub use tools::{FunctionCall, FunctionDeclaration, FunctionParameters, PropertyDetails, Tool};
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -151,6 +151,7 @@ pub struct SafetyRating {
 
 /// Citation metadata for content
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CitationMetadata {
     /// The citation sources
     pub citation_sources: Vec<CitationSource>,
@@ -158,6 +159,7 @@ pub struct CitationMetadata {
 
 /// Citation source
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CitationSource {
     /// The URI of the citation source
     pub uri: Option<String>,
@@ -175,6 +177,7 @@ pub struct CitationSource {
 
 /// A candidate response
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Candidate {
     /// The content of the candidate
     pub content: Content,
@@ -194,6 +197,7 @@ pub struct Candidate {
 
 /// Metadata about token usage
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UsageMetadata {
     /// The number of prompt tokens
     pub prompt_token_count: i32,
@@ -205,6 +209,7 @@ pub struct UsageMetadata {
 
 /// Response from the Gemini API for content generation
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct GenerationResponse {
     /// The candidates generated
     pub candidates: Vec<Candidate>,
@@ -239,6 +244,7 @@ pub struct BatchContentEmbeddingResponse {
 
 /// Feedback about the prompt
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptFeedback {
     /// The safety ratings for the prompt
     pub safety_ratings: Vec<SafetyRating>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -111,6 +111,13 @@ impl Message {
         }
     }
 
+    pub fn embed(text: impl Into<String>) -> Self {
+        Self {
+            content: Content::text(text),
+            role: Role::Model,
+        }
+    }
+
     /// Create a new function message with function response content from JSON
     pub fn function(name: impl Into<String>, response: serde_json::Value) -> Self {
         Self {
@@ -209,6 +216,27 @@ pub struct GenerationResponse {
     pub usage_metadata: Option<UsageMetadata>,
 }
 
+/// Content of the embedding
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContentEmbedding {
+    /// The values generated
+    pub values: Vec<f32>, //Maybe Quantize this
+}
+
+/// Response from the Gemini API for content embedding
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContentEmbeddingResponse {
+    /// The embeddings generated
+    pub embedding: ContentEmbedding,
+}
+
+/// Response from the Gemini API for batch content embedding
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchContentEmbeddingResponse {
+    /// The embeddings generated
+    pub embeddings: Vec<ContentEmbedding>,
+}
+
 /// Feedback about the prompt
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptFeedback {
@@ -267,6 +295,30 @@ pub struct GenerateContentRequest {
     /// The system instruction
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_instruction: Option<Content>,
+}
+
+/// Request to embed words
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedContentRequest {
+    /// The specified embedding model
+    pub model: String,
+    /// The chunks content to generate embeddings
+    pub content: Content,
+    /// The embedding task type (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_type: Option<TaskType>,
+    /// The title of the document (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_dimensionality: Option<i32>,
+}
+
+/// Request to batch embed requests
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEmbedContentsRequest {
+    /// The list of embed requests
+    pub requests: Vec<EmbedContentRequest>,
 }
 
 /// Configuration for generation
@@ -405,4 +457,26 @@ pub enum HarmBlockThreshold {
     BlockOnlyHigh,
     /// Never block content
     BlockNone,
+}
+
+/// Embedding Task types
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TaskType {
+    ///Used to generate embeddings that are optimized to assess text similarity
+    SemanticSimilarity,
+    ///Used to generate embeddings that are optimized to classify texts according to preset labels
+    Classification,
+    ///Used to generate embeddings that are optimized to cluster texts based on their similarities
+    Clustering,
+
+    ///Used to generate embeddings that are optimized for document search or information retrieval.
+    RetrievalDocument, 
+    RetrievalQuery, 
+    QuestionAnswering, 
+    FactVerification,
+
+    /// Used to retrieve a code block based on a natural language query, such as sort an array or reverse a linked list. 
+    /// Embeddings of the code blocks are computed using RETRIEVAL_DOCUMENT.
+    CodeRetrievalQuery
 }


### PR DESCRIPTION
## This pull request includes  

- Restructuring the client implementation
  -> Separated client from builder and added a new embed_builder

- Implementing the support for embedding endpoint
  -> Implemented embedding and batch embedding requests but no support for vector quantization

- New embedding and batch embedding examples
  -> Added two examples for new implementation

- Fixing problem with retrieving certain informations
  -> Specified camelCase for serialization/deserialization of response objects 
  
## Tests

- You can test embedding implementation via the new builder .embed_content
  ! title & output_dimensionality parameters haven't been tested but should work with newer version than text-embedding-001

- You can test the fix for the optional informations retrieval by trying to access those in a generateContent response
  ! only the usageMetadata have been tested

<br>

> @flachesis If you want to discuss feel free to send me a mail on avert45officiel@gmail.com