### PR TITLE
fix: move tokio to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ categories = ["api-bindings"]
 reqwest = { version = "^0.12.15", features = ["charset", "h2", "http2", "json", "stream", "macos-system-configuration", "rustls-tls"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-tokio = { version = "^1.28", features = ["full"] }
 thiserror = "^2.0.12"
 url = "^2.4"
 async-trait = "^0.1"
 futures = "^0.3.1"
 futures-util = "^0.3"
 base64 = "0.22.1"
+
+[dev-dependencies]
+tokio = { version = "^1.28", features = ["full"] }


### PR DESCRIPTION
This PR moves tokio to dev-dependencies, since it's currently used in tests only.
This fixes the compile error on target `wasm32-unknown-unknown`.
