### PR TITLE
DRAFT: Batch API: response decoding.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ async-trait = "^0.1"
 futures = "^0.3.1"
 futures-util = "^0.3"
 base64 = "0.22.1"
+tokio = { version = "^1.28", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "^1.28", features = ["full"] }

--- a/examples/batch_generate.rs
+++ b/examples/batch_generate.rs
@@ -11,7 +11,8 @@
 //! cargo run --package gemini-rust --example batch_generate
 //! ```
 
-use gemini_rust::{Gemini, Message};
+use gemini_rust::{BatchStatus, Gemini, Message};
+use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -34,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build();
 
     // Create the batch request
-    let batch_response = gemini
+    let batch = gemini
         .batch_generate_content_sync()
         .with_request(request1)
         .with_request(request2)
@@ -43,16 +44,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Print the batch information
     println!("Batch created successfully!");
-    println!("Batch ID: {}", batch_response.name);
-    println!("State: {}", batch_response.metadata.state);
-    println!(
-        "Request count: {}",
-        batch_response.metadata.batch_stats.request_count
-    );
+    println!("Batch Name: {}", batch.name());
 
-    if batch_response.metadata.state == "BATCH_STATE_PENDING" {
-        println!("Batch is currently processing. You would need to poll the batch status to get results.");
-        println!("Note: This is an async operation that may take some time to complete.");
+    // Wait for the batch to complete
+    println!("Waiting for batch to complete...");
+    match batch.wait_for_completion(Duration::from_secs(5)).await {
+        Ok(final_status) => {
+            // Print the final status
+            match final_status {
+                BatchStatus::Succeeded { results } => {
+                    println!("Batch succeeded!");
+                    for (i, response) in results.iter().enumerate() {
+                        println!("--- Response {} ---", i + 1);
+                        println!("{}", response.text());
+                    }
+                }
+                BatchStatus::Cancelled => {
+                    println!("Batch was cancelled.");
+                }
+                BatchStatus::Expired => {
+                    println!("Batch expired.");
+                }
+                _ => {
+                    println!(
+                        "Batch finished with an unexpected status: {:?}",
+                        final_status
+                    );
+                }
+            }
+        }
+        Err(e) => {
+            println!("Batch failed: {}", e);
+        }
     }
 
     Ok(())

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,0 +1,63 @@
+//! The Batch module for managing batch operations.
+
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+
+use crate::{
+    client::GeminiClient,
+    models::{BatchOperation, BatchStatus},
+    Error, Result,
+};
+
+/// Represents a long-running batch operation.
+pub struct Batch {
+    pub name: String,
+    client: Arc<GeminiClient>,
+}
+
+impl Batch {
+    /// Creates a new Batch instance.
+    pub(crate) fn new(name: String, client: Arc<GeminiClient>) -> Self {
+        Self { name, client }
+    }
+
+    /// Returns the name of the batch operation.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Retrieves the current status of the batch operation.
+    pub async fn status(&self) -> Result<BatchStatus> {
+        let operation: BatchOperation = self.client.get_batch_operation(&self.name).await?;
+        BatchStatus::from_operation(operation)
+    }
+
+    /// Cancels the batch operation.
+    pub async fn cancel(self) -> Result<()> {
+        self.client.cancel_batch_operation(&self.name).await
+    }
+
+    /// Waits for the batch operation to complete.
+    ///
+    /// This method polls the batch status with a specified delay until the operation
+    /// reaches a terminal state (Succeeded, Failed, Cancelled, or Expired).
+    pub async fn wait_for_completion(self, delay: Duration) -> Result<BatchStatus> {
+        loop {
+            match self.status().await {
+                Ok(status) => match status {
+                    BatchStatus::Succeeded { .. } | BatchStatus::Cancelled => return Ok(status),
+                    BatchStatus::Expired => {
+                        return Err(Error::BatchExpired {
+                            name: self.name.clone(),
+                        })
+                    }
+                    _ => sleep(delay).await,
+                },
+                Err(e) => match e {
+                    Error::BatchFailed { .. } => return Err(e),
+                    _ => sleep(delay).await,
+                },
+            }
+        }
+    }
+}

--- a/src/batch_builder.rs
+++ b/src/batch_builder.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use crate::{
+    batch::Batch,
     client::GeminiClient,
     models::{
-        BatchConfig, BatchGenerateContentRequest, BatchGenerateContentResponse, BatchRequestItem,
-        GenerateContentRequest, InputConfig, RequestMetadata, RequestsContainer,
+        BatchConfig, BatchGenerateContentRequest, BatchRequestItem, GenerateContentRequest,
+        InputConfig, RequestMetadata, RequestsContainer,
     },
     Result,
 };
@@ -52,9 +53,7 @@ impl BatchBuilder {
             .enumerate()
             .map(|(i, request)| BatchRequestItem {
                 request,
-                metadata: Some(RequestMetadata {
-                    key: format!("request-{}", i + 1),
-                }),
+                metadata: Some(RequestMetadata { key: i.to_string() }),
             })
             .collect();
 
@@ -70,10 +69,11 @@ impl BatchBuilder {
         }
     }
 
-    /// Execute the batch request
-    pub async fn execute(self) -> Result<BatchGenerateContentResponse> {
+    /// Execute the batch request and return a `Batch` handle
+    pub async fn execute(self) -> Result<Batch> {
         let client = self.client.clone();
         let request = self.build();
-        client.batch_generate_content_sync(request).await
+        let response = client.batch_generate_content_sync(request).await?;
+        Ok(Batch::new(response.name, client))
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,7 +7,7 @@ use crate::{
         BatchGenerateContentResponse, ContentEmbeddingResponse, EmbedContentRequest,
         GenerateContentRequest, GenerationResponse,
     },
-    Error, Result,
+    Batch, Error, Result,
 };
 use futures::stream::Stream;
 use reqwest::Client;
@@ -133,6 +133,49 @@ impl GeminiClient {
         Ok(response)
     }
 
+    /// Get a batch operation
+    pub(crate) async fn get_batch_operation<T: serde::de::DeserializeOwned>(
+        &self,
+        name: &str,
+    ) -> Result<T> {
+        let url = self.build_batch_url(name, None)?;
+        let response = self.http_client.get(url).send().await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await?;
+            return Err(Error::ApiError {
+                status_code: status.as_u16(),
+                message: error_text,
+            });
+        }
+
+        let response = response.json().await?;
+        Ok(response)
+    }
+
+    /// Cancel a batch operation
+    pub(crate) async fn cancel_batch_operation(&self, name: &str) -> Result<()> {
+        let url = self.build_batch_url(name, Some("cancel"))?;
+        let response = self
+            .http_client
+            .post(url)
+            .json(&serde_json::json!({}))
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_text = response.text().await?;
+            return Err(Error::ApiError {
+                status_code: status.as_u16(),
+                message: error_text,
+            });
+        }
+
+        Ok(())
+    }
+
     /// Post JSON to an endpoint
     async fn post_json<T: serde::Serialize>(&self, request: T, endpoint: &str) -> Result<Value> {
         let url = self.build_url(endpoint)?;
@@ -157,6 +200,16 @@ impl GeminiClient {
         let url_str = format!(
             "{}{}:{}?key={}",
             self.base_url, self.model, endpoint, self.api_key
+        );
+        Url::parse(&url_str).map_err(|e| Error::RequestError(e.to_string()))
+    }
+
+    /// Build a URL for a batch operation
+    fn build_batch_url(&self, name: &str, action: Option<&str>) -> Result<Url> {
+        let action_suffix = action.map_or("".to_string(), |a| format!(":{}", a));
+        let url_str = format!(
+            "{}{}{}?key={}",
+            self.base_url, name, action_suffix, self.api_key
         );
         Url::parse(&url_str).map_err(|e| Error::RequestError(e.to_string()))
     }
@@ -195,7 +248,7 @@ impl Gemini {
         model: String,
         base_url: String,
     ) -> Self {
-        let client = GeminiClient::with_base_url(api_key, model, base_url);
+        let client = GeminiClient::with_base_url(api_key.into(), model, base_url);
         Self {
             client: Arc::new(client),
         }
@@ -214,5 +267,9 @@ impl Gemini {
     /// Start building a synchronous batch content generation request
     pub fn batch_generate_content_sync(&self) -> BatchBuilder {
         BatchBuilder::new(self.client.clone())
+    }
+
+    pub fn batch(&self, name: String) -> Batch {
+        Batch::new(name, self.client.clone())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,6 +35,26 @@ pub enum Error {
     /// Error converting between types
     #[error("Try from error: {0}")]
     TryFromError(String),
+
+    /// Error indicating a batch operation has failed
+    #[error("Batch operation failed: {name}")]
+    BatchFailed { name: String, error: OperationError },
+
+    /// Error indicating a batch operation has expired
+    #[error("Batch operation expired: {name}")]
+    BatchExpired { name: String },
+
+    /// Error indicating an inconsistent state from the Batch API
+    #[error("Inconsistent batch state: {description}")]
+    InconsistentBatchState { description: String },
+}
+
+/// Represents an error within a long-running operation.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct OperationError {
+    pub code: i32,
+    pub message: String,
+    // details are not included as they are not consistently typed in the API
 }
 
 impl From<serde_json::Value> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! A Rust client library for Google's Gemini 2.0 API.
 
+mod batch;
 mod batch_builder;
 mod client;
 mod content_builder;
@@ -10,15 +11,18 @@ mod error;
 mod models;
 mod tools;
 
+pub use batch::Batch;
 pub use batch_builder::BatchBuilder;
 pub use client::Gemini;
 pub use content_builder::ContentBuilder;
 pub use error::Error;
 pub use models::{
-    BatchConfig, BatchMetadata, BatchRequestItem, BatchStats, Blob, Candidate, CitationMetadata,
+    BatchConfig, BatchGenerateContentResponseItem, BatchMetadata, BatchOperationResponse,
+    BatchRequestItem, BatchState, BatchStats, BatchStatus, Blob, Candidate, CitationMetadata,
     Content, FunctionCallingMode, GenerateContentRequest, GenerationConfig, GenerationResponse,
-    InputConfig, Message, Part, PromptTokenDetails, RequestMetadata, RequestsContainer, Role,
-    SafetyRating, TaskType, ThinkingConfig, UsageMetadata,
+    InlinedResponses, InputConfig, Message, OutputConfig, Part, PromptTokenDetails,
+    RequestMetadata, RequestsContainer, Role, SafetyRating, TaskType, ThinkingConfig,
+    UsageMetadata,
 };
 
 pub use tools::{FunctionCall, FunctionDeclaration, FunctionParameters, PropertyDetails, Tool};

--- a/src/models.rs
+++ b/src/models.rs
@@ -11,7 +11,7 @@ pub enum Role {
 }
 
 /// Content part that can be included in a message
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Part {
     /// Text content
@@ -42,7 +42,7 @@ pub enum Part {
 }
 
 /// Blob for a message part
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Blob {
     pub mime_type: String,
@@ -60,7 +60,7 @@ impl Blob {
 }
 
 /// Content of a message
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Content {
     /// Parts of the content
@@ -182,7 +182,7 @@ impl Message {
 }
 
 /// Safety rating for content
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SafetyRating {
     /// The category of the safety rating
     pub category: String,
@@ -191,7 +191,7 @@ pub struct SafetyRating {
 }
 
 /// Citation metadata for content
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CitationMetadata {
     /// The citation sources
@@ -199,7 +199,7 @@ pub struct CitationMetadata {
 }
 
 /// Citation source
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct CitationSource {
     /// The URI of the citation source
@@ -217,7 +217,7 @@ pub struct CitationSource {
 }
 
 /// A candidate response
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Candidate {
     /// The content of the candidate
@@ -237,7 +237,7 @@ pub struct Candidate {
 }
 
 /// Metadata about token usage
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageMetadata {
     /// The number of prompt tokens
@@ -256,7 +256,7 @@ pub struct UsageMetadata {
 }
 
 /// Details about prompt tokens by modality
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptTokenDetails {
     /// The modality (e.g., "TEXT")
@@ -266,7 +266,7 @@ pub struct PromptTokenDetails {
 }
 
 /// Response from the Gemini API for content generation
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerationResponse {
     /// The candidates generated
@@ -307,7 +307,7 @@ pub struct BatchContentEmbeddingResponse {
 }
 
 /// Feedback about the prompt
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptFeedback {
     /// The safety ratings for the prompt
@@ -338,12 +338,19 @@ impl GenerationResponse {
         self.candidates
             .iter()
             .flat_map(|c| {
-                c.content.parts.as_ref().map(|parts| {
-                    parts.iter().filter_map(|p| match p {
-                        Part::FunctionCall { function_call } => Some(function_call),
-                        _ => None,
-                    }).collect::<Vec<_>>()
-                }).unwrap_or_default()
+                c.content
+                    .parts
+                    .as_ref()
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|p| match p {
+                                Part::FunctionCall { function_call } => Some(function_call),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
             })
             .collect()
     }
@@ -353,15 +360,22 @@ impl GenerationResponse {
         self.candidates
             .iter()
             .flat_map(|c| {
-                c.content.parts.as_ref().map(|parts| {
-                    parts.iter().filter_map(|p| match p {
-                        Part::Text {
-                            text,
-                            thought: Some(true),
-                        } => Some(text.clone()),
-                        _ => None,
-                    }).collect::<Vec<_>>()
-                }).unwrap_or_default()
+                c.content
+                    .parts
+                    .as_ref()
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|p| match p {
+                                Part::Text {
+                                    text,
+                                    thought: Some(true),
+                                } => Some(text.clone()),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
             })
             .collect()
     }
@@ -371,12 +385,21 @@ impl GenerationResponse {
         self.candidates
             .iter()
             .flat_map(|c| {
-                c.content.parts.as_ref().map(|parts| {
-                    parts.iter().filter_map(|p| match p {
-                        Part::Text { text, thought } => Some((text.clone(), thought.unwrap_or(false))),
-                        _ => None,
-                    }).collect::<Vec<_>>()
-                }).unwrap_or_default()
+                c.content
+                    .parts
+                    .as_ref()
+                    .map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|p| match p {
+                                Part::Text { text, thought } => {
+                                    Some((text.clone(), thought.unwrap_or(false)))
+                                }
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
             })
             .collect()
     }
@@ -510,9 +533,25 @@ pub struct BatchMetadata {
     /// Batch statistics
     pub batch_stats: BatchStats,
     /// Current state of the batch
-    pub state: String,
+    pub state: BatchState,
     /// Name of the batch (duplicate)
     pub name: String,
+    /// The output configuration for the batch.
+    pub output: Option<OutputConfig>,
+}
+
+/// The state of a batch operation.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum BatchState {
+    BatchStatePending,
+    BatchStateInitializing,
+    BatchStateRunning,
+    BatchStateSucceeded,
+    BatchStateFailed,
+    BatchStateCancelled,
+    BatchStateExpired,
+    BatchStateUnspecified,
 }
 
 /// Statistics for the batch
@@ -520,13 +559,38 @@ pub struct BatchMetadata {
 #[serde(rename_all = "camelCase")]
 pub struct BatchStats {
     /// Total number of requests in the batch
-    pub request_count: String,
+    #[serde(deserialize_with = "from_str_to_i64")]
+    pub request_count: i64,
     /// Number of pending requests
-    pub pending_request_count: Option<String>,
+    #[serde(default, deserialize_with = "from_str_to_i64_optional")]
+    pub pending_request_count: Option<i64>,
     /// Number of completed requests
-    pub completed_request_count: Option<String>,
+    #[serde(default, deserialize_with = "from_str_to_i64_optional")]
+    pub completed_request_count: Option<i64>,
     /// Number of failed requests
-    pub failed_request_count: Option<String>,
+    #[serde(default, deserialize_with = "from_str_to_i64_optional")]
+    pub failed_request_count: Option<i64>,
+    /// Number of successful requests
+    #[serde(default, deserialize_with = "from_str_to_i64_optional")]
+    pub successful_request_count: Option<i64>,
+}
+
+fn from_str_to_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: String = serde::Deserialize::deserialize(deserializer)?;
+    s.parse::<i64>().map_err(serde::de::Error::custom)
+}
+
+fn from_str_to_i64_optional<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<String>::deserialize(deserializer)? {
+        Some(s) => s.parse::<i64>().map(Some).map_err(serde::de::Error::custom),
+        None => Ok(None),
+    }
 }
 
 /// Configuration for thinking (Gemini 2.5 series only)
@@ -754,4 +818,148 @@ pub enum TaskType {
     /// Used to retrieve a code block based on a natural language query, such as sort an array or reverse a linked list.
     /// Embeddings of the code blocks are computed using RETRIEVAL_DOCUMENT.
     CodeRetrievalQuery,
+}
+
+/// Represents the overall status of a batch operation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BatchStatus {
+    /// The operation is waiting to be processed.
+    Pending,
+    /// The operation is currently being processed.
+    Running {
+        processed_count: i64,
+        total_count: i64,
+    },
+    /// The operation has completed successfully.
+    Succeeded { results: Vec<GenerationResponse> },
+    /// The operation was cancelled by the user.
+    Cancelled,
+    /// The operation has expired.
+    Expired,
+}
+
+impl BatchStatus {
+    /// Creates a `BatchStatus` from a `BatchOperation` response.
+    pub(crate) fn from_operation(operation: BatchOperation) -> crate::Result<Self> {
+        if operation.done {
+            // The operation is complete. Determine the final state.
+            if let Some(error) = operation.error {
+                return Err(crate::Error::BatchFailed {
+                    name: operation.name,
+                    error,
+                });
+            }
+
+            match operation.response {
+                Some(mut response) => {
+                    // Sort responses by key to ensure correct order.
+                    response.inlined_responses.inlined_responses.sort_by_key(|item| {
+                        item.metadata.key.parse::<usize>().unwrap_or(0)
+                    });
+                    let results = response
+                        .inlined_responses
+                        .inlined_responses
+                        .into_iter()
+                        .map(|item| item.response)
+                        .collect();
+                    Ok(BatchStatus::Succeeded { results })
+                }
+                // If `done` is true with no error, a response is expected for success.
+                // If not, it might be a successful cancellation or an inconsistent state.
+                None => match operation.metadata.state {
+                    BatchState::BatchStateCancelled => Ok(BatchStatus::Cancelled),
+                    BatchState::BatchStateExpired => Ok(BatchStatus::Expired),
+                    BatchState::BatchStateSucceeded => Ok(BatchStatus::Succeeded { results: vec![] }), // Succeeded but with no data
+                    _ => Err(crate::Error::InconsistentBatchState {
+                        description: format!(
+                            "Operation is done but has no response or error. Final state is ambiguous: {:?}.",
+                            operation.metadata.state
+                        ),
+                    }),
+                },
+            }
+        } else {
+            // The operation is still in progress.
+            match operation.metadata.state {
+                BatchState::BatchStatePending | BatchState::BatchStateInitializing => {
+                    Ok(BatchStatus::Pending)
+                }
+                BatchState::BatchStateRunning => {
+                    let total_count = operation.metadata.batch_stats.request_count;
+                    let completed_count = operation
+                        .metadata
+                        .batch_stats
+                        .completed_request_count
+                        .unwrap_or(0);
+                    let failed_count = operation
+                        .metadata
+                        .batch_stats
+                        .failed_request_count
+                        .unwrap_or(0);
+                    Ok(BatchStatus::Running {
+                        processed_count: completed_count + failed_count,
+                        total_count,
+                    })
+                }
+                // Any other state is inconsistent with `done: false`.
+                terminal_state => Err(crate::Error::InconsistentBatchState {
+                    description: format!(
+                        "Operation is not done, but API reported a terminal state: {:?}.",
+                        terminal_state
+                    ),
+                }),
+            }
+        }
+    }
+}
+
+/// Represents a long-running operation from the Gemini API.
+#[derive(Debug, serde::Deserialize)]
+pub struct BatchOperation {
+    pub name: String,
+    pub metadata: BatchMetadata,
+    #[serde(default)]
+    pub done: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<crate::error::OperationError>,
+    pub response: Option<BatchOperationResponse>,
+}
+
+/// Represents the response of a batch operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchOperationResponse {
+    #[serde(rename = "@type")]
+    pub type_annotation: String,
+    pub inlined_responses: InlinedResponses,
+}
+
+/// Represents the output configuration of a batch operation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(untagged)]
+pub enum OutputConfig {
+    InlinedResponses(InlinedResponsesWrapper),
+}
+
+/// A wrapper for the doubly-nested inlined responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlinedResponsesWrapper {
+    pub inlined_responses: InlinedResponses,
+}
+
+/// A container for inlined responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InlinedResponses {
+    pub inlined_responses: Vec<BatchGenerateContentResponseItem>,
+}
+
+/// An item in a batch generate content response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BatchGenerateContentResponseItem {
+    pub response: GenerationResponse,
+    pub metadata: RequestMetadata,
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -196,7 +196,7 @@ impl PropertyDetails {
 }
 
 /// A function call made by the model
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunctionCall {
     /// The name of the function
     pub name: String,
@@ -237,7 +237,7 @@ impl FunctionCall {
 }
 
 /// A response from a function
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunctionResponse {
     /// The name of the function
     pub name: String,


### PR DESCRIPTION
Hello @flachesis!

## Problem

Current interface doesn't allow as to decode server response.

## Plan

- [x] Decoding IR-structures.
- [x] Type safe wrapper.
- [x] Tests.
  - [x] `cargo check` / `cargo check --examples` routine.
  - [x] Manual tests with valid API key.
  - [x] Examples fix.