### PR TITLE
Increase max output tokens in generation config from 1000 to 5000

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .with_user_message("Hello, can you tell me a joke about programming?")
         .with_generation_config(GenerationConfig {
             temperature: Some(0.7),
-            max_output_tokens: Some(1000),
+            max_output_tokens: Some(5000),
             ..Default::default()
         })
         .execute()


### PR DESCRIPTION
Fix output truncation by increasing max_output_tokens in generation config

- Increase max_output_tokens from 1000 to 5000 in simple.rs example
- Prevents incomplete responses due to insufficient token limits
- Ensures proper display of full AI-generated content