### PR TITLE
Add thoughtSignature support for Gemini 2.5 models

### DIFF
--- a/THOUGHT_SIGNATURE.md
+++ b/THOUGHT_SIGNATURE.md
@@ -1,0 +1,178 @@
+# thoughtSignature Support
+
+This update adds support for the `thoughtSignature` feature in Gemini 2.5 series models to gemini-rust.
+
+## What is thoughtSignature
+
+`thoughtSignature` is a new feature in Gemini 2.5 series models that provides an encrypted signature of the thinking process when the model makes function calls. This signature represents the model's internal reasoning process when making function call decisions.
+
+## New Features
+
+### 1. FunctionCall Structure Update
+
+The `FunctionCall` structure now includes an optional `thought_signature` field:
+
+```rust
+pub struct FunctionCall {
+    pub name: String,
+    pub args: serde_json::Value,
+    pub thought_signature: Option<String>,
+}
+```
+
+### 2. New Constructor Methods
+
+- `FunctionCall::new()` - Creates function call without thought signature (maintains backward compatibility)
+- `FunctionCall::with_thought_signature()` - Creates function call with thought signature
+
+```rust
+// Without thought signature
+let function_call = FunctionCall::new("function_name", args);
+
+// With thought signature
+let function_call = FunctionCall::with_thought_signature(
+    "function_name", 
+    args, 
+    "thought_signature_string"
+);
+```
+
+### 3. Part Enum Update
+
+The `Part::FunctionCall` variant now includes the `thought_signature` field:
+
+```rust
+FunctionCall {
+    function_call: super::tools::FunctionCall,
+    thought_signature: Option<String>,
+}
+```
+
+### 4. New API Methods
+
+`GenerationResponse` adds methods to retrieve function calls with their thought signatures:
+
+```rust
+// Get function calls and their corresponding thought signatures
+let function_calls_with_thoughts = response.function_calls_with_thoughts();
+for (function_call, thought_signature) in function_calls_with_thoughts {
+    println!("Function: {}", function_call.name);
+    if let Some(signature) = thought_signature {
+        println!("Thought Signature: {}", signature);
+    }
+}
+```
+
+## Usage Examples
+
+Please refer to `examples/thought_signature_example.rs` to learn how to:
+
+1. Enable thinking functionality
+2. Retrieve function calls with thought signatures
+3. Handle thought signature data
+4. **Maintain thinking context across multi-turn conversations**
+
+### Thought Signatures in Multi-turn Conversations
+
+Gemini API text and content generation calls are stateless. When using thinking in multi-turn interactions (such as chat), the model doesn't have access to thought context from previous turns.
+
+You can maintain thought context using thought signatures, which are encrypted representations of the model's internal thought process. When thinking and function calling are enabled, the model returns thought signatures in the response object. To ensure the model maintains context across multiple turns of a conversation, you must provide the thought signatures back to the model in subsequent requests.
+
+#### Important Usage Limitations
+
+1. **Complete Response Preservation**: Return the entire response with all parts containing signatures back to the model
+2. **Don't Concatenate Parts**: Don't concatenate parts with signatures together  
+3. **Don't Merge Parts**: Don't merge one part with a signature with another part without a signature
+
+#### Example Code
+
+```rust
+// First turn: Get function call with thought signature
+let response = client
+    .generate_content()
+    .with_user_message("What's the weather like?")
+    .with_tool(weather_tool)
+    .with_thinking_config(thinking_config)
+    .execute()
+    .await?;
+
+// Extract thought signature
+let (function_call, thought_signature) = response.function_calls_with_thoughts()[0];
+
+// Second turn: Maintain thinking context
+let mut conversation = client.generate_content();
+
+// Important: Include complete model response including thought signature
+let model_content = Content {
+    parts: Some(vec![Part::FunctionCall {
+        function_call: function_call.clone(),
+        thought_signature: thought_signature.cloned(), // Key: preserve original signature
+    }]),
+    role: Some(Role::Model),
+};
+conversation.contents.push(model_content);
+
+// Continue conversation...
+```
+
+## API Response Example
+
+When Gemini 2.5 Pro makes function calls, the response will include `thoughtSignature`:
+
+```json
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "functionCall": {
+              "name": "get_current_weather",
+              "args": {
+                "location": "Kaohsiung Zuoying District"
+              }
+            },
+            "thoughtSignature": "CtwFAVSoXO4WSz0Ri3HddDzPQzsB8EaYsiQobiBKOzGOaAPM..."
+          }
+        ],
+        "role": "model"
+      }
+    }
+  ]
+}
+```
+
+## Backward Compatibility
+
+All changes maintain backward compatibility:
+
+- Existing `FunctionCall::new()` method still works
+- Existing `function_calls()` method still returns the same results  
+- Serialization/deserialization automatically handles missing `thought_signature` fields
+
+## Testing
+
+Three new tests were added to verify functionality:
+
+1. `test_thought_signature_deserialization` - Tests deserialization of responses containing thought signatures
+2. `test_function_call_with_thought_signature` - Tests creating function calls with thought signatures
+3. `test_function_call_without_thought_signature` - Ensures backward compatibility
+4. `test_multi_turn_content_structure` - Tests multi-turn conversation structure
+
+Run tests:
+
+```bash
+cargo test test_thought_signature
+cargo test test_function_call
+cargo test test_multi_turn
+```
+
+## Important Notes
+
+- `thoughtSignature` functionality is only available in Gemini 2.5 series models
+- Requires enabling thinking functionality to generate thought signatures
+- **Must enable function calling simultaneously to receive thought signatures**
+- Thought signatures are encrypted strings representing the model's internal reasoning process
+- In multi-turn conversations, must return complete responses (with signatures) to the model
+- Don't modify, concatenate, or merge parts containing thought signatures
+- Thought signatures help the model maintain thinking context across conversation turns

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let call_content = Content {
             parts: Some(vec![Part::FunctionCall {
                 function_call: (*function_call).clone(),
+                thought_signature: None,
             }]),
             ..Default::default()
         };

--- a/examples/simple_thought_signature.rs
+++ b/examples/simple_thought_signature.rs
@@ -1,0 +1,56 @@
+use gemini_rust::{
+    FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails,
+    ThinkingConfig, Tool,
+};
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = env::var("GEMINI_API_KEY")?;
+    let client = Gemini::pro(api_key)?;
+
+    // Create a simple function tool
+    let weather_function = FunctionDeclaration::new(
+        "get_weather",
+        "Get current weather for a location",
+        FunctionParameters::object().with_property(
+            "location",
+            PropertyDetails::string("City name"),
+            true,
+        ),
+    );
+
+    // Configure thinking to enable thoughtSignature
+    let thinking_config = ThinkingConfig::new()
+        .with_dynamic_thinking()
+        .with_thoughts_included(true);
+
+    let response = client
+        .generate_content()
+        .with_user_message("What's the weather like in Tokyo?")
+        .with_tool(Tool::new(weather_function))
+        .with_function_calling_mode(FunctionCallingMode::Auto)
+        .with_thinking_config(thinking_config)
+        .execute()
+        .await?;
+
+    // Check function calls and thought signatures
+    let function_calls_with_thoughts = response.function_calls_with_thoughts();
+
+    for (function_call, thought_signature) in function_calls_with_thoughts {
+        println!("Function called: {}", function_call.name);
+        println!("Arguments: {}", function_call.args);
+
+        if let Some(signature) = thought_signature {
+            println!("Thought signature present: {} characters", signature.len());
+            println!(
+                "Signature preview: {}...",
+                &signature[..50.min(signature.len())]
+            );
+        } else {
+            println!("No thought signature");
+        }
+    }
+
+    Ok(())
+}

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -1,0 +1,268 @@
+/// Comprehensive example demonstrating thoughtSignature support in Gemini 2.5 Pro
+///
+/// This example shows:
+/// 1. How to enable thinking and function calling to receive thought signatures
+/// 2. How to extract thought signatures from function call responses
+/// 3. How to maintain thought context across multiple turns in a conversation
+///
+/// Key points about thought signatures:
+/// - Only available with Gemini 2.5 series models
+/// - Requires both thinking and function calling to be enabled
+/// - Must include the entire response with thought signatures in subsequent turns
+/// - Don't concatenate or merge parts with signatures
+///
+/// Thought signatures are encrypted representations of the model's internal
+/// thought process that help maintain context across conversation turns.
+use gemini_rust::{
+    FunctionCallingMode, FunctionDeclaration, FunctionParameters, FunctionResponse, Gemini,
+    PropertyDetails, ThinkingConfig, Tool,
+};
+use serde_json::json;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get API key from environment variable
+    let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+
+    // Create client using Gemini 2.5 Pro which supports thoughtSignature
+    let client = Gemini::pro(api_key).expect("unable to create Gemini API client");
+
+    println!("=== Gemini 2.5 Pro thoughtSignature Example ===\n");
+
+    // Define the weather function tool
+    let weather_function = FunctionDeclaration::new(
+        "get_current_weather",
+        "Get current weather information for a specified location",
+        FunctionParameters::object().with_property(
+            "location",
+            PropertyDetails::string("City and region, e.g., Kaohsiung Zuoying District"),
+            true,
+        ),
+    );
+
+    let weather_tool = Tool::new(weather_function);
+
+    // Configure thinking to enable thoughtSignature
+    let thinking_config = ThinkingConfig::new()
+        .with_dynamic_thinking()
+        .with_thoughts_included(true);
+
+    // First request: Ask about weather (expecting function call with thoughtSignature)
+    println!("--- Step 1: Asking about weather (expecting function call) ---");
+
+    let response = client
+        .generate_content()
+        .with_system_instruction("Please respond in Traditional Chinese")
+        .with_user_message("What's the weather like in Kaohsiung Zuoying District right now?")
+        .with_tool(weather_tool)
+        .with_function_calling_mode(FunctionCallingMode::Auto)
+        .with_thinking_config(thinking_config)
+        .execute()
+        .await?;
+
+    // Check for function calls with thought signatures
+    let function_calls_with_thoughts = response.function_calls_with_thoughts();
+
+    if !function_calls_with_thoughts.is_empty() {
+        println!("Function calls received:");
+        for (function_call, thought_signature) in function_calls_with_thoughts {
+            println!("  Function: {}", function_call.name);
+            println!("  Arguments: {}", function_call.args);
+
+            if let Some(signature) = thought_signature {
+                println!("  Thought Signature: {}", signature);
+                println!("  Thought Signature Length: {} characters", signature.len());
+            } else {
+                println!("  No thought signature provided");
+            }
+            println!();
+
+            // Mock function response
+            let weather_data = json!({
+                "temperature": "25°C",
+                "condition": "sunny",
+                "humidity": "60%",
+                "wind": "light breeze",
+                "location": function_call.get::<String>("location").unwrap_or_default()
+            });
+
+            println!("Mock weather response: {}", weather_data);
+            println!();
+
+            // Continue the conversation with function response
+            println!("--- Step 2: Providing function response ---");
+            let function_response = FunctionResponse::new(&function_call.name, weather_data);
+
+            let final_response = client
+                .generate_content()
+                .with_system_instruction("Please respond in Traditional Chinese")
+                .with_user_message(
+                    "What's the weather like in Kaohsiung Zuoying District right now?",
+                )
+                .with_function_response(
+                    &function_call.name,
+                    function_response.response.unwrap_or_default(),
+                )
+                .execute()
+                .await?;
+
+            println!("Final response: {}", final_response.text());
+
+            // Display usage metadata
+            if let Some(usage) = &final_response.usage_metadata {
+                println!("\nToken usage:");
+                println!("  Prompt tokens: {}", usage.prompt_token_count);
+                println!(
+                    "  Response tokens: {}",
+                    usage.candidates_token_count.unwrap_or(0)
+                );
+                if let Some(thinking_tokens) = usage.thoughts_token_count {
+                    println!("  Thinking tokens: {}", thinking_tokens);
+                }
+                println!("  Total tokens: {}", usage.total_token_count);
+            }
+
+            // --- Step 3: Multi-turn conversation with thought context ---
+            println!("\n--- Step 3: Multi-turn conversation maintaining thought context ---");
+            println!("IMPORTANT: To maintain thought context, we must include the complete");
+            println!("previous response with thought signatures in the next turn.");
+
+            // Create a multi-turn conversation that includes the previous context
+            // We need to include ALL parts from the previous responses to maintain thought context
+            let mut conversation_builder = client.generate_content();
+
+            // Add system instruction
+            conversation_builder = conversation_builder
+                .with_system_instruction("Please respond in Traditional Chinese");
+
+            // Add the original user message
+            conversation_builder = conversation_builder.with_user_message(
+                "What's the weather like in Kaohsiung Zuoying District right now?",
+            );
+
+            // IMPORTANT: Add the model's response with the function call INCLUDING the thought signature
+            // This maintains the thought context for the next turn
+            // DO NOT concatenate parts or merge signatures - include the complete original part
+            let model_content = gemini_rust::Content {
+                parts: Some(vec![gemini_rust::Part::FunctionCall {
+                    function_call: function_call.clone(),
+                    thought_signature: thought_signature.cloned(), // This is crucial for context
+                }]),
+                role: Some(gemini_rust::Role::Model),
+            };
+            conversation_builder.contents.push(model_content);
+
+            // Add the function response
+            conversation_builder = conversation_builder.with_function_response(
+                &function_call.name,
+                json!({
+                    "temperature": "25°C",
+                    "condition": "sunny",
+                    "humidity": "60%",
+                    "wind": "light breeze",
+                    "location": function_call.get::<String>("location").unwrap_or_default()
+                }),
+            );
+
+            // Add the model's text response (complete the conversation history)
+            let model_text_content = gemini_rust::Content {
+                parts: Some(vec![gemini_rust::Part::Text {
+                    text: final_response.text(),
+                    thought: None,
+                }]),
+                role: Some(gemini_rust::Role::Model),
+            };
+            conversation_builder.contents.push(model_text_content);
+
+            // Now ask a follow-up question that can benefit from the thought context
+            // The model will have access to its previous reasoning through the thought signature
+            conversation_builder = conversation_builder.with_user_message("Is this weather suitable for outdoor sports? Please recommend some appropriate activities.");
+
+            // Add the weather tool again for potential follow-up function calls
+            let weather_tool_followup = Tool::new(FunctionDeclaration::new(
+                "get_current_weather",
+                "Get current weather information for a specified location",
+                FunctionParameters::object().with_property(
+                    "location",
+                    PropertyDetails::string("City and region, e.g., Kaohsiung Zuoying District"),
+                    true,
+                ),
+            ));
+
+            conversation_builder = conversation_builder
+                .with_tool(weather_tool_followup)
+                .with_function_calling_mode(FunctionCallingMode::Auto)
+                .with_thinking_config(
+                    ThinkingConfig::new()
+                        .with_dynamic_thinking()
+                        .with_thoughts_included(true),
+                );
+
+            let followup_response = conversation_builder.execute().await?;
+
+            println!("Follow-up question: Is this weather suitable for outdoor sports? Please recommend some appropriate activities.");
+            println!("Follow-up response: {}", followup_response.text());
+
+            // Check if there are any new function calls with thought signatures in the follow-up
+            let followup_function_calls = followup_response.function_calls_with_thoughts();
+            if !followup_function_calls.is_empty() {
+                println!("\nFollow-up function calls:");
+                for (fc, ts) in followup_function_calls {
+                    println!("  Function: {}", fc.name);
+                    println!("  Arguments: {}", fc.args);
+                    if let Some(sig) = ts {
+                        println!("  New thought signature: {} characters", sig.len());
+                    }
+                }
+            }
+
+            // Display thinking process for follow-up
+            let followup_thoughts = followup_response.thoughts();
+            if !followup_thoughts.is_empty() {
+                println!("\nFollow-up thinking summaries:");
+                for (i, thought) in followup_thoughts.iter().enumerate() {
+                    println!("  Follow-up thought {}: {}", i + 1, thought);
+                }
+            }
+
+            // Display follow-up usage metadata
+            if let Some(usage) = &followup_response.usage_metadata {
+                println!("\nFollow-up token usage:");
+                println!("  Prompt tokens: {}", usage.prompt_token_count);
+                println!(
+                    "  Response tokens: {}",
+                    usage.candidates_token_count.unwrap_or(0)
+                );
+                if let Some(thinking_tokens) = usage.thoughts_token_count {
+                    println!("  Thinking tokens: {}", thinking_tokens);
+                }
+                println!("  Total tokens: {}", usage.total_token_count);
+            }
+
+            println!("\n=== Multi-turn conversation completed ===");
+            println!("Key takeaways:");
+            println!("1. Thought signatures help maintain context across conversation turns");
+            println!("2. Include the complete response (with signatures) in subsequent requests");
+            println!("3. Don't modify or concatenate parts that contain thought signatures");
+            println!("4. Thought signatures are only available with thinking + function calling");
+            println!(
+                "5. The model can build upon its previous reasoning when signatures are preserved"
+            );
+        }
+    } else {
+        println!("No function calls in response");
+        println!("Response text: {}", response.text());
+    }
+
+    // Display any thoughts from the initial response
+    let thoughts = response.thoughts();
+    if !thoughts.is_empty() {
+        println!("\nInitial thinking summaries:");
+        for (i, thought) in thoughts.iter().enumerate() {
+            println!("  Thought {}: {}", i + 1, thought);
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ mod embed_builder;
 mod models;
 mod tools;
 
+#[cfg(test)]
+mod tests;
+
 pub use batch::{Batch, BatchStatus, Error as BatchError};
 pub use batch_builder::BatchBuilder;
 pub use client::{Error as ClientError, Gemini, Model};
@@ -17,11 +20,13 @@ pub use content_builder::ContentBuilder;
 pub use models::{
     BatchConfig, BatchGenerateContentResponseItem, BatchMetadata, BatchOperationResponse,
     BatchRequestItem, BatchResultItem, BatchState, BatchStats, Blob, Candidate, CitationMetadata,
-    Content, FunctionCallingMode, GenerateContentRequest, GenerationConfig, GenerationResponse,
-    InlinedResponses, InputConfig, Message, MultiSpeakerVoiceConfig, OutputConfig, Part,
-    PrebuiltVoiceConfig, PromptTokenDetails, RequestMetadata, RequestsContainer, Role,
-    SafetyRating, SpeakerVoiceConfig, SpeechConfig, TaskType, ThinkingConfig, UsageMetadata,
-    VoiceConfig,
+    Content, FunctionCallingConfig, FunctionCallingMode, GenerateContentRequest, GenerationConfig,
+    GenerationResponse, InlinedResponses, InputConfig, Message, MultiSpeakerVoiceConfig,
+    OutputConfig, Part, PrebuiltVoiceConfig, PromptTokenDetails, RequestMetadata,
+    RequestsContainer, Role, SafetyRating, SpeakerVoiceConfig, SpeechConfig, TaskType,
+    ThinkingConfig, ToolConfig, UsageMetadata, VoiceConfig,
 };
 
-pub use tools::{FunctionCall, FunctionDeclaration, FunctionParameters, PropertyDetails, Tool};
+pub use tools::{
+    FunctionCall, FunctionDeclaration, FunctionParameters, FunctionResponse, PropertyDetails, Tool,
+};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,171 @@
+use crate::{FunctionCall, GenerationResponse, Part};
+use serde_json::json;
+
+#[test]
+fn test_thought_signature_deserialization() {
+    // Test JSON that includes thoughtSignature like in the provided API response
+    let json_response = json!({
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": "get_current_weather",
+                                "args": {
+                                    "location": "Kaohsiung Zuoying District"
+                                }
+                            },
+                            "thoughtSignature": "CtwFAVSoXO4WSz0Ri3HddDzPQzsB8EaYsiQobiBKOzGOaAPM0d4DewrzUmhCnZbdboz+n+6v503fcy4epZC2bomn247laY6RHtKTc0UA8scj1DW/Y8w9AsfvjDX1adpIi043qjivTtowjxKAIesKoO69mFj6HTmGRI6sE1hamsIblZGZypowxnBQmxqJftl1aebB7kQN+MoYSeX+OU1z/8G+RXE+cb9cvwdAGIZjHXoGgEaIigYlrjTkZjRGBiI+gC2AcLNe32MHVla2/dmV8O7k8Cl45ksH+4srYABtmXLxjxwQK6s2bjVngvaRcBTCK4AUHiDb1j54n3Fls5J1i9k2sd6OcJYJuRlfwuxv2RMZ+V8zLdNthfSWtZwuJslkOD3uZCkEhO/hI6nAKcyuSokdAKtOw9g6LWORnEQoUJ+BaTVymN1tuJzbzrS9kPP5d3QJfFdQaILkk8CUdnGOEcngvlINN4MGNTQYN+0Au/JFWDWj33T5LZWkbDMp+yIpqFkZuRYwjW/9KOR6qFbxzvJyQcAKTxf0Sq7UfHTYBXTVp0/N4cDWRv+5DF0UOp+6emnPslCmaRK8JEGkmKkYXCzR6PpopfdzHHSDQHbNjjwr0h9ADZKehiB/cB1Jjy0oyBOM3HSHyuzcP8CO4NoAXOUM/VP5P41ys9TdeaPZAZ1E3cGQI4pifFVPdy3o33QSYqS1ce5Wxbeud06+d+sz2O7jJrfHMdgYpcO/2RcXQyK/GVIlDkWyxpYtBZhlkh3vLxPVmV/JJv5DQSS3YNTFSbfbwC8DtrI6YNFK5Vo07cl6mAY+U8b4ziFJk2HGuO27jq5EnhJE6v39HCfXTa8cKaLzpIURJSOs12S1rc3pqXdv4VBL6dp+Yjr8eQPxYRP93QzZMFXcYZ+Vc2H5mbnXbvTxVdYT7Qpu7aK1o6csSOMOx47NzZnOnlTWNJUxtU5UIZJ2JelOt/NsWnVJZY8D"
+                        }
+                    ],
+                    "role": "model"
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 70,
+            "candidatesTokenCount": 21,
+            "totalTokenCount": 255,
+            "thoughtsTokenCount": 164
+        },
+        "modelVersion": "gemini-2.5-pro",
+        "responseId": "CCm8aJjzBaWh1MkP_cLEgQo"
+    });
+
+    // Test deserialization
+    let response: GenerationResponse = serde_json::from_value(json_response).unwrap();
+
+    // Verify basic structure
+    assert_eq!(response.candidates.len(), 1);
+    let candidate = &response.candidates[0];
+    assert_eq!(candidate.finish_reason, Some("STOP".to_string()));
+
+    // Check content parts
+    let parts = candidate.content.parts.as_ref().unwrap();
+    assert_eq!(parts.len(), 1);
+
+    // Verify the part is a function call with thought signature
+    match &parts[0] {
+        Part::FunctionCall {
+            function_call,
+            thought_signature,
+        } => {
+            assert_eq!(function_call.name, "get_current_weather");
+            assert_eq!(function_call.args["location"], "Kaohsiung Zuoying District");
+
+            // Verify thought signature is present and not empty
+            assert!(thought_signature.is_some());
+            let signature = thought_signature.as_ref().unwrap();
+            assert!(!signature.is_empty());
+            assert!(signature.starts_with("CtwFAVSoXO4WSz0Ri3HddDzPQzsB8EaYsiQobiBKOzGOaAPM"));
+        }
+        _ => panic!("Expected FunctionCall part"),
+    }
+
+    // Test the function_calls_with_thoughts method
+    let function_calls_with_thoughts = response.function_calls_with_thoughts();
+    assert_eq!(function_calls_with_thoughts.len(), 1);
+
+    let (function_call, thought_signature) = &function_calls_with_thoughts[0];
+    assert_eq!(function_call.name, "get_current_weather");
+    assert!(thought_signature.is_some());
+
+    // Test usage metadata with thinking tokens
+    assert!(response.usage_metadata.is_some());
+    let usage = response.usage_metadata.as_ref().unwrap();
+    assert_eq!(usage.thoughts_token_count, Some(164));
+}
+
+#[test]
+fn test_function_call_with_thought_signature() {
+    // Test creating a FunctionCall with thought signature
+    let function_call = FunctionCall::with_thought_signature(
+        "test_function",
+        json!({"param": "value"}),
+        "test_thought_signature",
+    );
+
+    assert_eq!(function_call.name, "test_function");
+    assert_eq!(function_call.args["param"], "value");
+    assert_eq!(
+        function_call.thought_signature,
+        Some("test_thought_signature".to_string())
+    );
+
+    // Test serialization
+    let serialized = serde_json::to_string(&function_call).unwrap();
+    println!("Serialized FunctionCall: {}", serialized);
+
+    // Test deserialization
+    let deserialized: FunctionCall = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized, function_call);
+}
+
+#[test]
+fn test_function_call_without_thought_signature() {
+    // Test creating a FunctionCall without thought signature (backward compatibility)
+    let function_call = FunctionCall::new("test_function", json!({"param": "value"}));
+
+    assert_eq!(function_call.name, "test_function");
+    assert_eq!(function_call.args["param"], "value");
+    assert_eq!(function_call.thought_signature, None);
+
+    // Test serialization should not include thought_signature field when None
+    let serialized = serde_json::to_string(&function_call).unwrap();
+    println!("Serialized FunctionCall without thought: {}", serialized);
+    assert!(!serialized.contains("thought_signature"));
+}
+
+#[test]
+fn test_multi_turn_content_structure() {
+    // Test that we can create proper multi-turn content structure for maintaining thought context
+    use crate::{Content, Part, Role};
+
+    // Simulate a function call with thought signature from first turn
+    let function_call = FunctionCall::with_thought_signature(
+        "get_weather",
+        json!({"location": "Tokyo"}),
+        "sample_thought_signature",
+    );
+
+    // Create model content with function call and thought signature
+    let model_content = Content {
+        parts: Some(vec![Part::FunctionCall {
+            function_call: function_call.clone(),
+            thought_signature: Some("sample_thought_signature".to_string()),
+        }]),
+        role: Some(Role::Model),
+    };
+
+    // Verify structure
+    assert!(model_content.parts.is_some());
+    assert_eq!(model_content.role, Some(Role::Model));
+
+    // Test serialization of the complete structure first
+    let serialized = serde_json::to_string(&model_content).unwrap();
+    println!("Serialized multi-turn content: {}", serialized);
+
+    // Verify it contains the thought signature
+    assert!(serialized.contains("thoughtSignature"));
+    assert!(serialized.contains("sample_thought_signature"));
+
+    let parts = model_content.parts.unwrap();
+    assert_eq!(parts.len(), 1);
+
+    match &parts[0] {
+        Part::FunctionCall {
+            function_call,
+            thought_signature,
+        } => {
+            assert_eq!(function_call.name, "get_weather");
+            assert_eq!(
+                thought_signature.as_ref().unwrap(),
+                "sample_thought_signature"
+            );
+        }
+        _ => panic!("Expected FunctionCall part"),
+    }
+}

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -202,6 +202,9 @@ pub struct FunctionCall {
     pub name: String,
     /// The arguments for the function
     pub args: serde_json::Value,
+    /// The thought signature for the function call (Gemini 2.5 series only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thought_signature: Option<String>,
 }
 
 #[derive(Debug, Snafu)]
@@ -228,6 +231,20 @@ impl FunctionCall {
         Self {
             name: name.into(),
             args,
+            thought_signature: None,
+        }
+    }
+
+    /// Create a new function call with thought signature
+    pub fn with_thought_signature(
+        name: impl Into<String>,
+        args: serde_json::Value,
+        thought_signature: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            args,
+            thought_signature: Some(thought_signature.into()),
         }
     }
 


### PR DESCRIPTION
- Introduced `thought_signature` field in FunctionCall structure.
- Added methods for creating function calls with and without thought signatures.
- Updated API methods to retrieve function calls along with their thought signatures.
- Implemented tests for thought signature serialization and deserialization.
- Created examples demonstrating thought signature usage in multi-turn conversations.