### PR TITLE
Caching support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ✨ Features
 
+#### Content Caching API Support
+- **New `CacheBuilder`**: Added comprehensive caching API support with fluent builder pattern for creating cached content
+- **`CachedContentHandle`**: New handle type for managing cached content lifecycle (get, update, delete)
+- **Content Caching Integration**: Added `with_cached_content()` method to `ContentBuilder` for using cached content in generation requests
+- **TTL and Expiration Support**: Full support for TTL-based and absolute time-based cache expiration
+- **Cache Management**: Complete CRUD operations for cached content with proper error handling and resource cleanup
+
 #### File-Based Batch Processing for Large Jobs
 - **New `execute_as_file()` method**: Added a new method to the `BatchBuilder` for submitting a large number of requests, ideal for jobs that might exceed API size limits.
 - **Automatic Result Handling**: The library now automatically downloads and parses result files for batches processed via the file-based method, delivering results seamlessly.

--- a/examples/cache_basic.rs
+++ b/examples/cache_basic.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create cached content with the full story for analysis
     let cache = client
         .create_cache()
-        .with_display_name("Grief Eater Story Analysis Cache")
+        .with_display_name("Grief Eater Story Analysis Cache")?
         .with_system_instruction("You are a literary analyst specialized in horror and supernatural fiction. Analyze stories for themes, character development, narrative techniques, and psychological elements.")
         .with_user_message("Please read and analyze this story:")
         .with_user_message(GRIEF_EATER_STORY)

--- a/examples/cache_basic.rs
+++ b/examples/cache_basic.rs
@@ -1,0 +1,107 @@
+use gemini_rust::{Gemini, Model};
+use std::time::Duration;
+
+// Include the story text at compile time
+const GRIEF_EATER_STORY: &str = include_str!("../test_data/grief_eater.txt");
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable must be set");
+
+    let client = Gemini::with_model(api_key, Model::Gemini25FlashLite)?;
+
+    println!("Creating cached content with the full story text...");
+
+    // Create cached content with the full story for analysis
+    let cache = client
+        .create_cache()
+        .with_display_name("Grief Eater Story Analysis Cache")
+        .with_system_instruction("You are a literary analyst specialized in horror and supernatural fiction. Analyze stories for themes, character development, narrative techniques, and psychological elements.")
+        .with_user_message("Please read and analyze this story:")
+        .with_user_message(GRIEF_EATER_STORY)
+        .with_ttl(Duration::from_secs(3600)) // Cache for 1 hour
+        .execute()
+        .await?;
+
+    println!("✅ Cache created successfully: {}", cache.name());
+
+    // Demonstrate cache retrieval to show token count
+    println!("\nRetrieving cache information...");
+    let cached_content = cache.get().await?;
+    println!("📋 Cache details:");
+    println!("  - Name: {}", cached_content.name);
+    println!(
+        "  - Display Name: {}",
+        cached_content
+            .display_name
+            .as_ref()
+            .unwrap_or(&"N/A".to_string())
+    );
+    println!("  - Model: {}", cached_content.model);
+    println!("  - Created: {}", cached_content.create_time);
+    println!("  - Updated: {}", cached_content.update_time);
+    println!(
+        "  - Total tokens: {}",
+        cached_content.usage_metadata.total_token_count
+    );
+    if let Some(expire_time) = cached_content.expiration.expire_time {
+        println!("  - Expires: {}", expire_time);
+    }
+
+    // Ask several analytical questions using the cached content
+    println!("\n=== Question 1: Main Theme ===");
+    let response1 = client
+        .generate_content()
+        .with_cached_content(&cache)
+        .with_user_message("What is the central theme of this story? How does the protagonist's relationship with grief evolve?")
+        .execute()
+        .await?;
+
+    println!("🤖 {}", response1.text());
+
+    println!("\n=== Question 2: Narrative Technique ===");
+    let response2 = client
+        .generate_content()
+        .with_cached_content(&cache)
+        .with_user_message("Analyze the narrative technique. How does the author use the protagonist's childhood nightmare as a literary device?")
+        .execute()
+        .await?;
+
+    println!("🤖 {}", response2.text());
+
+    println!("\n=== Question 3: Character Arc ===");
+    let response3 = client
+        .generate_content()
+        .with_cached_content(&cache)
+        .with_user_message("Describe the protagonist's character arc. What does he learn about grief by the end of the story?")
+        .execute()
+        .await?;
+
+    println!("🤖 {}", response3.text());
+
+    println!("\n=== Question 4: Symbolism ===");
+    let response4 = client
+        .generate_content()
+        .with_cached_content(&cache)
+        .with_user_message("What symbolic meaning does the grandfather's pocket knife hold in the story's resolution?")
+        .execute()
+        .await?;
+
+    println!("🤖 {}", response4.text());
+
+    // Clean up by deleting the cache
+    println!("\nCleaning up cache...");
+    match cache.delete().await {
+        Ok(_) => println!("✅ Cache deleted successfully"),
+        Err((cache, error)) => {
+            println!("❌ Failed to delete cache: {}", error);
+            println!(
+                "Cache handle returned for potential retry: {}",
+                cache.name()
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/examples/multi_speaker_tts.rs
+++ b/examples/multi_speaker_tts.rs
@@ -115,8 +115,12 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
             // Display usage metadata if available
             if let Some(usage_metadata) = &response.usage_metadata {
                 println!("\n📊 Usage Statistics:");
-                println!("   Prompt tokens: {}", usage_metadata.prompt_token_count);
-                println!("   Total tokens: {}", usage_metadata.total_token_count);
+                if let Some(prompt_tokens) = usage_metadata.prompt_token_count {
+                    println!("   Prompt tokens: {}", prompt_tokens);
+                }
+                if let Some(total_tokens) = usage_metadata.total_token_count {
+                    println!("   Total tokens: {}", total_tokens);
+                }
                 if let Some(thoughts_tokens) = usage_metadata.thoughts_token_count {
                     println!("   Thinking tokens: {}", thoughts_tokens);
                 }

--- a/examples/simple_speech_generation.rs
+++ b/examples/simple_speech_generation.rs
@@ -90,8 +90,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Display usage metadata if available
             if let Some(usage_metadata) = &response.usage_metadata {
                 println!("\n📊 Usage Statistics:");
-                println!("   Prompt tokens: {}", usage_metadata.prompt_token_count);
-                println!("   Total tokens: {}", usage_metadata.total_token_count);
+                if let Some(prompt_tokens) = usage_metadata.prompt_token_count {
+                    println!("   Prompt tokens: {}", prompt_tokens);
+                }
+                if let Some(total_tokens) = usage_metadata.total_token_count {
+                    println!("   Total tokens: {}", total_tokens);
+                }
             }
         },
         Err(e) => {

--- a/examples/thinking_advanced.rs
+++ b/examples/thinking_advanced.rs
@@ -137,10 +137,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(usage) = &complex_response.usage_metadata {
         println!("Token usage statistics:");
         println!("  Prompt tokens: {}", usage.prompt_token_count);
-        println!(
-            "  Response tokens: {}",
-            usage.candidates_token_count.unwrap_or(0)
-        );
+        println!("  Response tokens: {}", usage.candidates_token_count);
         if let Some(thinking_tokens) = usage.thoughts_token_count {
             println!("  Thinking tokens: {}", thinking_tokens);
         }

--- a/examples/thinking_advanced.rs
+++ b/examples/thinking_advanced.rs
@@ -136,12 +136,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display token usage statistics
     if let Some(usage) = &complex_response.usage_metadata {
         println!("Token usage statistics:");
-        println!("  Prompt tokens: {}", usage.prompt_token_count);
-        println!("  Response tokens: {}", usage.candidates_token_count);
+        if let Some(prompt_tokens) = usage.prompt_token_count {
+            println!("  Prompt tokens: {}", prompt_tokens);
+        }
+        if let Some(response_tokens) = usage.candidates_token_count {
+            println!("  Response tokens: {}", response_tokens);
+        }
         if let Some(thinking_tokens) = usage.thoughts_token_count {
             println!("  Thinking tokens: {}", thinking_tokens);
         }
-        println!("  Total tokens: {}", usage.total_token_count);
+        if let Some(total_tokens) = usage.total_token_count {
+            println!("  Total tokens: {}", total_tokens);
+        }
     }
 
     Ok(())

--- a/examples/thinking_basic.rs
+++ b/examples/thinking_basic.rs
@@ -41,10 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(usage) = &response1.usage_metadata {
         println!("Token usage:");
         println!("  Prompt tokens: {}", usage.prompt_token_count);
-        println!(
-            "  Response tokens: {}",
-            usage.candidates_token_count.unwrap_or(0)
-        );
+        println!("  Response tokens: {}", usage.candidates_token_count);
         if let Some(thinking_tokens) = usage.thoughts_token_count {
             println!("  Thinking tokens: {}", thinking_tokens);
         }

--- a/examples/thinking_basic.rs
+++ b/examples/thinking_basic.rs
@@ -40,12 +40,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display token usage
     if let Some(usage) = &response1.usage_metadata {
         println!("Token usage:");
-        println!("  Prompt tokens: {}", usage.prompt_token_count);
-        println!("  Response tokens: {}", usage.candidates_token_count);
+        if let Some(prompt_tokens) = usage.prompt_token_count {
+            println!("  Prompt tokens: {}", prompt_tokens);
+        }
+        if let Some(response_tokens) = usage.candidates_token_count {
+            println!("  Response tokens: {}", response_tokens);
+        }
         if let Some(thinking_tokens) = usage.thoughts_token_count {
             println!("  Thinking tokens: {}", thinking_tokens);
         }
-        println!("  Total tokens: {}\n", usage.total_token_count);
+        if let Some(total_tokens) = usage.total_token_count {
+            println!("  Total tokens: {}\n", total_tokens);
+        }
     }
 
     // Example 2: Set specific thinking budget

--- a/examples/thinking_curl_equivalent.rs
+++ b/examples/thinking_curl_equivalent.rs
@@ -95,12 +95,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Show token usage
     if let Some(usage) = &response2.usage_metadata {
         println!("Token usage:");
-        println!("  Prompt tokens: {}", usage.prompt_token_count);
-        println!("  Response tokens: {}", usage.candidates_token_count);
+        if let Some(prompt_tokens) = usage.prompt_token_count {
+            println!("  Prompt tokens: {}", prompt_tokens);
+        }
+        if let Some(response_tokens) = usage.candidates_token_count {
+            println!("  Response tokens: {}", response_tokens);
+        }
         if let Some(thinking_tokens) = usage.thoughts_token_count {
             println!("  Thinking tokens: {}", thinking_tokens);
         }
-        println!("  Total tokens: {}", usage.total_token_count);
+        if let Some(total_tokens) = usage.total_token_count {
+            println!("  Total tokens: {}", total_tokens);
+        }
     }
 
     // Method 3: Demonstrate different thinking budget settings

--- a/examples/thinking_curl_equivalent.rs
+++ b/examples/thinking_curl_equivalent.rs
@@ -96,10 +96,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(usage) = &response2.usage_metadata {
         println!("Token usage:");
         println!("  Prompt tokens: {}", usage.prompt_token_count);
-        println!(
-            "  Response tokens: {}",
-            usage.candidates_token_count.unwrap_or(0)
-        );
+        println!("  Response tokens: {}", usage.candidates_token_count);
         if let Some(thinking_tokens) = usage.thoughts_token_count {
             println!("  Thinking tokens: {}", thinking_tokens);
         }

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -113,10 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(usage) = &final_response.usage_metadata {
                 println!("\nToken usage:");
                 println!("  Prompt tokens: {}", usage.prompt_token_count);
-                println!(
-                    "  Response tokens: {}",
-                    usage.candidates_token_count.unwrap_or(0)
-                );
+                println!("  Response tokens: {}", usage.candidates_token_count);
                 if let Some(thinking_tokens) = usage.thoughts_token_count {
                     println!("  Thinking tokens: {}", thinking_tokens);
                 }
@@ -230,10 +227,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(usage) = &followup_response.usage_metadata {
                 println!("\nFollow-up token usage:");
                 println!("  Prompt tokens: {}", usage.prompt_token_count);
-                println!(
-                    "  Response tokens: {}",
-                    usage.candidates_token_count.unwrap_or(0)
-                );
+                println!("  Response tokens: {}", usage.candidates_token_count);
                 if let Some(thinking_tokens) = usage.thoughts_token_count {
                     println!("  Thinking tokens: {}", thinking_tokens);
                 }

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -112,12 +112,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Display usage metadata
             if let Some(usage) = &final_response.usage_metadata {
                 println!("\nToken usage:");
-                println!("  Prompt tokens: {}", usage.prompt_token_count);
-                println!("  Response tokens: {}", usage.candidates_token_count);
+                if let Some(prompt_tokens) = usage.prompt_token_count {
+                    println!("  Prompt tokens: {}", prompt_tokens);
+                }
+                if let Some(response_tokens) = usage.candidates_token_count {
+                    println!("  Response tokens: {}", response_tokens);
+                }
                 if let Some(thinking_tokens) = usage.thoughts_token_count {
                     println!("  Thinking tokens: {}", thinking_tokens);
                 }
-                println!("  Total tokens: {}", usage.total_token_count);
+                if let Some(total_tokens) = usage.total_token_count {
+                    println!("  Total tokens: {}", total_tokens);
+                }
             }
 
             // --- Step 3: Multi-turn conversation with thought context ---
@@ -226,12 +232,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Display follow-up usage metadata
             if let Some(usage) = &followup_response.usage_metadata {
                 println!("\nFollow-up token usage:");
-                println!("  Prompt tokens: {}", usage.prompt_token_count);
-                println!("  Response tokens: {}", usage.candidates_token_count);
+                if let Some(prompt_tokens) = usage.prompt_token_count {
+                    println!("  Prompt tokens: {}", prompt_tokens);
+                }
+                if let Some(response_tokens) = usage.candidates_token_count {
+                    println!("  Response tokens: {}", response_tokens);
+                }
                 if let Some(thinking_tokens) = usage.thoughts_token_count {
                     println!("  Thinking tokens: {}", thinking_tokens);
                 }
-                println!("  Total tokens: {}", usage.total_token_count);
+                if let Some(total_tokens) = usage.total_token_count {
+                    println!("  Total tokens: {}", total_tokens);
+                }
             }
 
             println!("\n=== Multi-turn conversation completed ===");

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,244 @@
+//! The Cache module for managing cached content operations.
+//!
+//! This module provides the [`CachedContentHandle`] struct, which is a handle to a cached content
+//! resource on the Gemini API. It allows for retrieving, updating, and deleting the cached content.
+//!
+//! The cache builder [`CacheBuilder`] provides a fluent API for creating cached content with
+//! system instructions, conversation history, tools, and TTL configuration.
+//!
+//! ## Cache Usage
+//!
+//! Cached content allows you to cache large context (like system instructions and conversation
+//! history) to reduce costs and improve performance for repeated API calls.
+//!
+//! ## Example usage:
+//! ```rust,ignore
+//! use gemini_rust::{Gemini, CacheExpiration};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let client = Gemini::new(std::env::var("GEMINI_API_KEY")?)?;
+//!     
+//!     // Create a cache with system instruction and TTL
+//!     let cache = client
+//!         .create_cache()
+//!         .with_model("models/gemini-2.5-flash")
+//!         .with_system_instruction("You are a helpful assistant")
+//!         .with_user_message("Hello, how are you?")
+//!         .with_ttl(std::time::Duration::from_secs(3600)) // 1 hour
+//!         .execute()
+//!         .await?;
+//!
+//!     // Use the cached content in generation
+//!     let response = client
+//!         .generate_content()
+//!         .with_cached_content(&cache)
+//!         .with_user_message("What can you help me with?")
+//!         .execute()
+//!         .await?;
+//!
+//!     println!("Response: {}", response.text());
+//!     Ok(())
+//! }
+//! ```
+
+use snafu::{ResultExt, Snafu};
+use std::{result::Result, sync::Arc, time::Duration};
+
+use crate::{
+    client::{Error as ClientError, GeminiClient},
+    models::{
+        CacheExpirationRequest, CachedContent, Content, CreateCachedContentRequest,
+        DeleteCachedContentResponse,
+    },
+    tools::Tool,
+    ToolConfig,
+};
+
+#[derive(Debug, Snafu)]
+pub enum Error {
+    #[snafu(display("client invocation error"))]
+    Client { source: Box<ClientError> },
+
+    #[snafu(display("expiration (TTL or expire time) is required for cache creation"))]
+    MissingExpiration,
+}
+
+/// Represents a cached content resource, providing methods to manage its lifecycle.
+///
+/// A `CachedContentHandle` object is a handle to a cached content resource on the Gemini API.
+/// It allows you to retrieve, update, or delete the cached content.
+pub struct CachedContentHandle {
+    /// The unique resource name of the cached content, e.g., `cachedContents/cache-xxxxxxxx`.
+    pub name: String,
+    client: Arc<GeminiClient>,
+}
+
+impl CachedContentHandle {
+    /// Creates a new CachedContentHandle instance.
+    pub(crate) fn new(name: String, client: Arc<GeminiClient>) -> Self {
+        Self { name, client }
+    }
+
+    /// Returns the unique resource name of the cached content.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Retrieves the cached content configuration by making an API call.
+    pub async fn get(&self) -> Result<CachedContent, Error> {
+        self.client
+            .get_cached_content(&self.name)
+            .await
+            .map_err(Box::new)
+            .context(ClientSnafu)
+    }
+
+    /// Updates the cached content configuration (typically the TTL).
+    pub async fn update(&self, expiration: CacheExpirationRequest) -> Result<CachedContent, Error> {
+        self.client
+            .update_cached_content(&self.name, expiration)
+            .await
+            .map_err(Box::new)
+            .context(ClientSnafu)
+    }
+
+    /// Deletes the cached content resource from the server.
+    pub async fn delete(self) -> Result<DeleteCachedContentResponse, (Self, ClientError)> {
+        match self.client.delete_cached_content(&self.name).await {
+            Ok(response) => Ok(response),
+            Err(e) => Err((self, e)),
+        }
+    }
+}
+
+/// Builder for creating cached content with a fluent API.
+pub struct CacheBuilder {
+    client: Arc<GeminiClient>,
+    display_name: Option<String>,
+    contents: Vec<Content>,
+    system_instruction: Option<Content>,
+    tools: Vec<Tool>,
+    tool_config: Option<ToolConfig>,
+    expiration: Option<CacheExpirationRequest>,
+}
+
+impl CacheBuilder {
+    /// Creates a new CacheBuilder instance.
+    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+        Self {
+            client,
+            display_name: None,
+            contents: Vec::new(),
+            system_instruction: None,
+            tools: Vec::new(),
+            tool_config: None,
+            expiration: None,
+        }
+    }
+
+    /// Set a display name for the cached content.
+    /// Maximum 128 Unicode characters.
+    pub fn with_display_name<S: Into<String>>(mut self, display_name: S) -> Self {
+        self.display_name = Some(display_name.into());
+        self
+    }
+
+    /// Set the system instruction for the cached content.
+    pub fn with_system_instruction<S: Into<String>>(mut self, instruction: S) -> Self {
+        self.system_instruction = Some(Content::text(instruction.into()));
+        self
+    }
+
+    /// Add a user message to the cached content.
+    pub fn with_user_message<S: Into<String>>(mut self, message: S) -> Self {
+        self.contents
+            .push(crate::Message::user(message.into()).content);
+        self
+    }
+
+    /// Add a model message to the cached content.
+    pub fn with_model_message<S: Into<String>>(mut self, message: S) -> Self {
+        self.contents
+            .push(crate::Message::model(message.into()).content);
+        self
+    }
+
+    /// Add content directly to the cached content.
+    pub fn with_content(mut self, content: Content) -> Self {
+        self.contents.push(content);
+        self
+    }
+
+    /// Add multiple contents to the cached content.
+    pub fn with_contents(mut self, contents: Vec<Content>) -> Self {
+        self.contents.extend(contents);
+        self
+    }
+
+    /// Add a tool to the cached content.
+    pub fn with_tool(mut self, tool: Tool) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    /// Add multiple tools to the cached content.
+    pub fn with_tools(mut self, tools: Vec<Tool>) -> Self {
+        self.tools.extend(tools);
+        self
+    }
+
+    /// Set the tool configuration.
+    pub fn with_tool_config(mut self, tool_config: ToolConfig) -> Self {
+        self.tool_config = Some(tool_config);
+        self
+    }
+
+    /// Set the TTL (Time To Live) for the cached content.
+    /// The cache will automatically expire after this duration.
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.expiration = Some(CacheExpirationRequest::from_ttl(ttl));
+        self
+    }
+
+    /// Set an explicit expiration time for the cached content.
+    pub fn with_expire_time(mut self, expire_time: time::OffsetDateTime) -> Self {
+        self.expiration = Some(CacheExpirationRequest::from_expire_time(expire_time));
+        self
+    }
+
+    /// Execute the cache creation request.
+    pub async fn execute(self) -> Result<CachedContentHandle, Error> {
+        let model = self.client.model.to_string();
+        let expiration = self.expiration.ok_or(Error::MissingExpiration)?;
+
+        let cached_content = CreateCachedContentRequest {
+            display_name: self.display_name,
+            model,
+            contents: if self.contents.is_empty() {
+                None
+            } else {
+                Some(self.contents)
+            },
+            tools: if self.tools.is_empty() {
+                None
+            } else {
+                Some(self.tools)
+            },
+            system_instruction: self.system_instruction,
+            tool_config: self.tool_config,
+            expiration,
+        };
+
+        let response = self
+            .client
+            .create_cached_content(cached_content)
+            .await
+            .map_err(Box::new)
+            .context(ClientSnafu)?;
+
+        let cache_name = response.name;
+
+        Ok(CachedContentHandle::new(cache_name, self.client))
+    }
+}

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -7,8 +7,8 @@ use crate::{
         FunctionCallingConfig, GenerateContentRequest, SpeakerVoiceConfig, SpeechConfig,
         ThinkingConfig, ToolConfig,
     },
-    Content, FunctionCallingMode, FunctionDeclaration, GenerationConfig, GenerationResponse,
-    Message, Role, Tool,
+    CachedContentHandle, Content, FunctionCallingMode, FunctionDeclaration, GenerationConfig,
+    GenerationResponse, Message, Role, Tool,
 };
 
 /// Builder for content generation requests
@@ -19,6 +19,7 @@ pub struct ContentBuilder {
     tools: Option<Vec<Tool>>,
     tool_config: Option<ToolConfig>,
     system_instruction: Option<Content>,
+    cached_content: Option<String>,
 }
 
 impl ContentBuilder {
@@ -31,6 +32,7 @@ impl ContentBuilder {
             tools: None,
             tool_config: None,
             system_instruction: None,
+            cached_content: None,
         }
     }
 
@@ -111,6 +113,13 @@ impl ContentBuilder {
                 self.contents.push(content.with_role(message.role));
             }
         }
+        self
+    }
+
+    /// Use cached content for this request.
+    /// This allows reusing previously cached system instructions and conversation history.
+    pub fn with_cached_content(mut self, cached_content: &CachedContentHandle) -> Self {
+        self.cached_content = Some(cached_content.name().to_string());
         self
     }
 
@@ -336,6 +345,7 @@ impl ContentBuilder {
             tools: self.tools,
             tool_config: self.tool_config,
             system_instruction: self.system_instruction,
+            cached_content: self.cached_content,
         }
     }
 
@@ -358,6 +368,7 @@ impl ContentBuilder {
             tools: self.tools,
             tool_config: self.tool_config,
             system_instruction: self.system_instruction,
+            cached_content: self.cached_content,
         };
 
         self.client.generate_content_stream(request).await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 
 mod batch;
 mod batch_builder;
+mod cache;
 mod client;
 mod content_builder;
 mod embed_builder;
@@ -16,19 +17,23 @@ mod tests;
 
 pub use batch::{Batch, BatchStatus, Error as BatchError};
 pub use batch_builder::BatchBuilder;
+pub use cache::{CacheBuilder, CachedContentHandle, Error as CacheError};
 pub use client::{Error as ClientError, Gemini, Model};
 pub use content_builder::ContentBuilder;
 pub use files::{FileBuilder, GeminiFile};
 pub use models::{
     BatchConfig, BatchFileItem, BatchGenerateContentResponseItem, BatchMetadata,
     BatchOperationResponse, BatchRequestItem, BatchResultItem, BatchState, BatchStats, Blob,
-    BlockReason, Candidate, CitationMetadata, Content, File, FileState, FinishReason,
-    FunctionCallingConfig, FunctionCallingMode, GenerateContentRequest, GenerationConfig,
-    GenerationResponse, HarmBlockThreshold, HarmCategory, HarmProbability, InlinedResponses,
-    InputConfig, Message, Modality, MultiSpeakerVoiceConfig, OperationResult, Part,
-    PrebuiltVoiceConfig, PromptTokenDetails, RequestMetadata, RequestsContainer, Role,
-    SafetyRating, SpeakerVoiceConfig, SpeechConfig, TaskType, ThinkingConfig, ToolConfig,
-    UsageMetadata, VoiceConfig,
+    BlockReason, CacheExpirationRequest, CacheExpirationResponse, CacheUsageMetadata,
+    CachedContent, CachedContentSummary, Candidate, CitationMetadata, Content,
+    CreateCachedContentRequest, CreateCachedContentResponse, DeleteCachedContentResponse, File,
+    FileState, FinishReason, FunctionCallingConfig, FunctionCallingMode, GenerateContentRequest,
+    GenerationConfig, GenerationResponse, GetCachedContentResponse, HarmBlockThreshold,
+    HarmCategory, HarmProbability, InlinedResponses, InputConfig, ListCachedContentsResponse,
+    Message, Modality, MultiSpeakerVoiceConfig, OperationResult, Part, PrebuiltVoiceConfig,
+    PromptTokenDetails, RequestMetadata, RequestsContainer, Role, SafetyRating, SpeakerVoiceConfig,
+    SpeechConfig, TaskType, ThinkingConfig, ToolConfig, UpdateCachedContentResponse, UsageMetadata,
+    VoiceConfig,
 };
 
 pub use tools::{

--- a/src/models.rs
+++ b/src/models.rs
@@ -333,18 +333,27 @@ pub struct Candidate {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageMetadata {
-    /// The number of prompt tokens
-    pub prompt_token_count: i32,
-    /// The number of response tokens
-    pub candidates_token_count: i32,
-    /// The total number of tokens
-    pub total_token_count: i32,
+    /// The number of prompt tokens (null if request processing failed)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_token_count: Option<i32>,
+    /// The number of response tokens (null if generation failed)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub candidates_token_count: Option<i32>,
+    /// The total number of tokens (null if individual counts unavailable)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_token_count: Option<i32>,
     /// The number of thinking tokens (Gemini 2.5 series only)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thoughts_token_count: Option<i32>,
     /// Detailed prompt token information
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_tokens_details: Option<Vec<PromptTokenDetails>>,
+    /// The number of cached content tokens (batch API)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_content_token_count: Option<i32>,
+    /// Detailed cache token information (batch API)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_tokens_details: Option<Vec<PromptTokenDetails>>,
 }
 
 /// Details about prompt tokens by modality

--- a/src/models.rs
+++ b/src/models.rs
@@ -336,8 +336,7 @@ pub struct UsageMetadata {
     /// The number of prompt tokens
     pub prompt_token_count: i32,
     /// The number of response tokens
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub candidates_token_count: Option<i32>,
+    pub candidates_token_count: i32,
     /// The total number of tokens
     pub total_token_count: i32,
     /// The number of thinking tokens (Gemini 2.5 series only)
@@ -567,6 +566,9 @@ pub struct GenerateContentRequest {
     /// The system instruction
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_instruction: Option<Content>,
+    /// The cached content to use
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_content: Option<String>,
 }
 
 /// Request to embed words
@@ -958,7 +960,7 @@ impl SpeakerVoiceConfig {
 }
 
 /// Configuration for tools
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolConfig {
     /// The function calling config
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -966,14 +968,14 @@ pub struct ToolConfig {
 }
 
 /// Configuration for function calling
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunctionCallingConfig {
     /// The mode for function calling
     pub mode: FunctionCallingMode,
 }
 
 /// Mode for function calling
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FunctionCallingMode {
     /// The model may use function calling
@@ -1278,5 +1280,198 @@ pub struct ListFilesResponse {
     #[serde(default)]
     pub files: Vec<File>,
     /// A token to retrieve the next page of results.
+    pub next_page_token: Option<String>,
+}
+
+/// Cached content resource returned by the API (with all server-provided fields).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedContent {
+    /// The resource name of the cached content.
+    /// Format: cachedContents/{id}
+    pub name: String,
+
+    /// The name of the model used for cached content.
+    /// Format: models/{model}
+    pub model: String,
+
+    /// Output only. Creation time of the cached content.
+    #[serde(with = "time::serde::rfc3339")]
+    pub create_time: OffsetDateTime,
+
+    /// Output only. Last update time of the cached content.
+    #[serde(with = "time::serde::rfc3339")]
+    pub update_time: OffsetDateTime,
+
+    /// Output only. Usage metadata for the cached content.
+    pub usage_metadata: CacheUsageMetadata,
+
+    /// Expiration information for the cached content.
+    #[serde(flatten)]
+    pub expiration: CacheExpirationResponse,
+
+    /// The user-generated display name (if provided).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+
+    /// The cached contents (may be omitted in some API responses for size).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents: Option<Vec<Content>>,
+
+    /// The cached tools (may be omitted in some API responses for size).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<super::tools::Tool>>,
+
+    /// The cached system instruction (may be omitted in some API responses for size).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<Content>,
+
+    /// The cached tool config (may be omitted in some API responses for size).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_config: Option<ToolConfig>,
+}
+
+/// Usage metadata specifically for cached content (more predictable than general UsageMetadata).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheUsageMetadata {
+    /// Total tokens in the cached content.
+    pub total_token_count: i32,
+}
+
+/// Expiration configuration for cached content in requests (union type).
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(untagged)]
+pub enum CacheExpirationRequest {
+    /// Timestamp in UTC of when this resource is considered expired.
+    /// Uses RFC 3339 format.
+    ExpireTime {
+        #[serde(with = "time::serde::rfc3339")]
+        expire_time: OffsetDateTime,
+    },
+    /// New TTL for this resource, input only.
+    /// A duration in seconds with up to nine fractional digits, ending with 's'.
+    /// Example: "3.5s" or "86400s".
+    Ttl { ttl: String },
+}
+
+impl CacheExpirationRequest {
+    /// Create expiration with TTL from a Duration.
+    pub fn from_ttl(duration: std::time::Duration) -> Self {
+        Self::Ttl {
+            ttl: format!("{}s", duration.as_secs()),
+        }
+    }
+
+    /// Create expiration with specific expire time.
+    pub fn from_expire_time(expire_time: OffsetDateTime) -> Self {
+        Self::ExpireTime { expire_time }
+    }
+}
+
+/// Expiration information in cached content responses.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CacheExpirationResponse {
+    /// Timestamp in UTC of when this resource is considered expired.
+    /// This is always provided on output, regardless of what was sent on input.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
+    pub expire_time: Option<OffsetDateTime>,
+    /// TTL that was set for this resource (input only, may not be present in response).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+}
+
+/// Request for creating cached content.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateCachedContentRequest {
+    /// The user-generated meaningful display name of the cached content.
+    /// Maximum 128 Unicode characters.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+
+    /// Required. The name of the model to use for cached content.
+    /// Format: models/{model}
+    pub model: String,
+
+    /// Optional. Input only. Immutable. The content to cache.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contents: Option<Vec<Content>>,
+
+    /// Optional. Input only. Immutable. A list of tools the model may use to generate the next response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<super::tools::Tool>>,
+
+    /// Optional. Input only. Immutable. Developer set system instruction. Currently text only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<Content>,
+
+    /// Optional. Input only. Immutable. Tool config. This config is shared for all tools.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_config: Option<ToolConfig>,
+
+    /// Expiration configuration for the cached content.
+    #[serde(flatten)]
+    pub expiration: CacheExpirationRequest,
+}
+
+/// Response from creating cached content.
+pub type CreateCachedContentResponse = CachedContent;
+
+/// Response from getting cached content.
+pub type GetCachedContentResponse = CachedContent;
+
+/// Response from updating cached content.
+pub type UpdateCachedContentResponse = CachedContent;
+
+/// Response from deleting cached content.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DeleteCachedContentResponse {
+    /// HTTP status and metadata
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success: Option<bool>,
+}
+
+/// Summary of cached content (used in list operations, may omit large content fields).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CachedContentSummary {
+    /// The resource name of the cached content.
+    pub name: String,
+
+    /// The name of the model used for cached content.
+    pub model: String,
+
+    /// Creation time of the cached content.
+    #[serde(with = "time::serde::rfc3339")]
+    pub create_time: OffsetDateTime,
+
+    /// Last update time of the cached content.
+    #[serde(with = "time::serde::rfc3339")]
+    pub update_time: OffsetDateTime,
+
+    /// Usage metadata for the cached content.
+    pub usage_metadata: CacheUsageMetadata,
+
+    /// Expiration information.
+    #[serde(flatten)]
+    pub expiration: CacheExpirationResponse,
+
+    /// Display name if provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+}
+
+/// Response from listing cached contents.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ListCachedContentsResponse {
+    /// The list of cached content summaries.
+    #[serde(default)]
+    pub cached_contents: Vec<CachedContentSummary>,
+    /// A token to retrieve the next page of results.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_page_token: Option<String>,
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3,7 +3,7 @@ use snafu::{ResultExt, Snafu};
 use std::collections::HashMap;
 
 /// Tool that can be used by the model
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum Tool {
     /// Function-based tool
@@ -19,7 +19,7 @@ pub enum Tool {
 }
 
 /// Empty configuration for Google Search tool
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GoogleSearchConfig {}
 
 impl Tool {
@@ -46,7 +46,7 @@ impl Tool {
 }
 
 /// Declaration of a function that can be called by the model
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunctionDeclaration {
     /// The name of the function
     pub name: String,
@@ -72,7 +72,7 @@ impl FunctionDeclaration {
 }
 
 /// Parameters for a function
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FunctionParameters {
     /// The type of the parameters
     #[serde(rename = "type")]
@@ -116,7 +116,7 @@ impl FunctionParameters {
 }
 
 /// Details about a property
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PropertyDetails {
     /// The type of the property
     #[serde(rename = "type")]

--- a/test_data/grief_eater.txt
+++ b/test_data/grief_eater.txt
@@ -1,0 +1,213 @@
+THE FIRST TIME I ate someone’s grief, it was an accident.
+
+My aunt had just died, and my cousin couldn’t stop crying at the funeral. She clutched her mother’s wedding ring so tight her knuckles grew white. When she hugged me, she pressed the ring into my palm.
+
+“I can’t look at it anymore,” she said. “Just take it away.”
+
+I slipped it into my pocket, and something strange happened on the drive home. A warm sensation spread through my gut, like I’d swallowed a shot of good whiskey. By the time I parked in my driveway, I felt freaking amazing—light, almost euphoric.
+
+Meanwhile, my cousin called to thank me. She’d finally slept through the night. “It’s like a weight lifted,” she said.
+
+I didn’t make the connection until two weeks later. I was stress-eating a gas station cherry cupcake—the kind with that nuclear-red icing that stains everything it touches. The ring remained in my pocket, and when I pulled it out to look at it, some of that sticky icing smeared across the metal. Without thinking, I licked it clean, and when the ring touched my tongue, it dissolved, melting like cotton candy while that same warmth flooded my system, only stronger this time. Much stronger.
+
+That’s when I understood what had happened. Somehow, I ate her grief.
+
+Five years passed, and I turned it into a business. Not officially, of course. You can’t exactly put “Grief Eater” on a business card. But word spread among the desperate.
+
+The process was simple. Bring me something that connects you to your dead loved one. Something that holds your pain. I consume it, and your grief disappears. I charged based on the intensity—a thousand for a parent, five hundred for a sibling, two-fifty for a grandparent. Pets were a flat hundred. The pricing wasn’t based on science, but on how much the grief would screw me up afterwards.
+
+But I didn’t tell my clients what happened to their grief afterward. It didn’t disappear. It lived inside me. I’d consumed the emotional trauma of seventy-eight dead loved ones, and each one had left something behind—a whisper, an itch, a memory—that  wasn’t mine.
+
+I called them the Chorus.
+
+Most days, I could handle them. They were just background noise, the mental equivalent of a TV left on in another room. But lately, they’d been getting louder. More demanding. The whispers had become conversations. Conversations had escalated into arguments. Pleas had replaced the arguments.
+
+Let us out. Let us see them. We miss them.
+
+I ignored them and kept eating. The warmth that followed consuming grief had become addictive, better than any drug I’d tried. And I’d tried plenty. The business was just an excuse to keep feeling that rush.
+
+Ever since I was a kid, I’d had the same recurring nightmare—being trapped inside my body, conscious but unable to move or speak, while something else controlled me from within. I’d wake up screaming, drenched in sweat, grateful to be back in control. As I got older, the nightmares became less frequent, but more intense. The idea of being reduced to a passenger in my own flesh terrified me more than death itself. I’d rather cease to exist than exist as a prisoner inside my body.
+
+I never connected these nightmares to my new profession. Never saw the warning signs. Until it was too late.
+
+On a rainy Tuesday, a woman brought me her brother’s baseball cap. He’d killed himself three months ago, and she hadn’t slept well since. She passed me the cap with trembling hands.
+
+“Will it hurt?” she asked, her fingers still gripping the frayed edge.
+
+“Not you,” I said.
+
+When she left, I locked the door and stuffed the cap into my mouth. The fabric dissolved against my tongue, releasing a bitter wave of sorrow that made my eyes water. I chewed faster. The sooner I got it down, the sooner the pain transformed into that familiar warmth.
+
+Except this time, something different happened.
+
+As the last threads disappeared down my throat, I heard a man’s voice, clear as day, say, “Finally.”
+
+And then my hands weren’t my hands anymore.
+
+I tried to move them, but they stayed flat on the desk. I tried to stand, but my legs ignored me. My breathing sped up, but I wasn’t the one speeding it up.
+
+“You’ve been so selfish,” the voice said. “Keeping us all in here. Not letting us reach them.”
+
+I tried to respond, but my mouth wouldn’t open. Panic crawled up my spine as I realized what was happening. I was still here, still conscious, but I wasn’t in control anymore. I was a passenger in my own body.
+
+My lifelong nightmare was unfolding in real time. The terror I’d woken from a hundred times was now my waking reality.
+
+“It’s our turn now,” another voice in my head said. A woman’s voice, elderly, unfamiliar. “You’ve kept us quiet long enough.”
+
+The next few hours were a blur of psychological torture. My body moved without my permission. My hands opened drawers, searched through files, and found my client list. My mouth formed words that weren’t mine, practicing different voices, different cadences. The Chorus was figuring out how to drive.
+
+They let me surface just enough to feel the full horror of my situation. I screamed, but they pushed me back down into the darkness. The claustrophobia of being caged inside my skull was worse than any physical pain I’d ever experienced—like being buried alive but still able to watch the world through a window.
+
+By nightfall, they had a plan.
+
+I woke up on my kitchen floor surrounded by shattered glass. The clock said 3:47 AM. I’d lost nine hours.
+
+My phone showed seventeen missed calls from unknown numbers. There was blood under my fingernails, and my mouth tasted like copper and salt. When I tried to stand, the world tilted sideways.
+
+“What the hell?” I said, but the words felt wrong in my mouth, like my tongue had forgotten how to shape them.
+
+“We’ve been waiting for this,” a voice that wasn’t mine said. It was coming from inside my head, but it wasn’t a thought. It was someone else. Someone new. “For someone who could hold enough of us.”
+
+I stumbled to the bathroom and flipped on the light. In the mirror, my face looked wrong. My expressions weren’t mine. My eyes focused and unfocused, as if someone else was controlling them.
+
+“No,” I said. “This isn’t happening.”
+
+“Oh, but it is,” the voice replied. “You’ve been so generous, making space for us. And now we’re going to return the favor.”
+
+My hand rose to my face, but I wasn’t the one moving it. I tried to scream, but my lips stayed sealed.
+
+My worst nightmare had always been this: losing control. Being trapped inside while someone else drove. And now it was happening. This wasn’t a metaphor or an exaggeration—this was the literal manifestation of the terror that had haunted my sleep since childhood, come to life in the waking world.
+
+“Don’t fight it,” whispered another voice, a woman’s this time. “You’ll just make it worse.”
+
+And suddenly, the Chorus wasn’t background noise anymore. They were front and center, rising like a flood, and I was drowning in them.
+
+They took my body out for a test drive, and I remained conscious for every terrible moment of it. I saw everything through my eyes, but I was just a passenger now. They used my voice to talk to each other, arguing over who got control next.
+
+“The brother should go first,” said my mouth in a voice that wasn’t mine. “He’s the newest. He hasn’t seen his sister yet.”
+
+My head nodded without my permission.
+
+“Fifteen minutes each,” said another voice using my vocal cords. “Until we figure out a better system.”
+
+They were dividing me up like I was a time share property. And there was nothing I could do but watch.
+
+The suffocating horror of being reduced to an observer in your own life is impossible to describe to someone who hasn’t experienced it.
+
+My body drove to the woman’s house, the one who brought me her brother’s cap yesterday. The Chorus knew where she lived because her brother knew. They rang the doorbell.
+
+When she answered, her face transformed from confusion to terror.
+
+“Tommy?” she said.
+
+“Hey, sis,” my mouth said in her brother’s voice. “I’m back.”
+
+She backed away, shaking her head. “No. You’re that person—the one who took the cap. What are you doing?”
+
+“It’s complicated,” my mouth said. “But I needed to see you. To tell you, it wasn’t your fault.”
+
+They were using me like a puppet, and I couldn’t even scream. Every childhood fear of possession, every adult anxiety about losing autonomy—it was all playing out in high definition. This wasn’t just a nightmare; it was the nightmare that defined me.
+
+The woman was crying now. “This isn’t funny. You need to leave.”
+
+“Remember that summer at Lake Michigan? When I pushed you off the dock and you lost your new sunglasses? I said a fish took them.”
+
+Her face went pale. “Nobody knew about that.”
+
+“I did. I do.” My hand reached out to touch her face. “I need you to do something for me now.”
+
+“What?” she whispered.
+
+“I need you to give him something else. Something with more grief in it. My journal. It’s under the mattress.”
+
+No! I screamed inside my mind. Don’t listen to him!
+
+But of course, she couldn’t hear me. Nobody could. I sat trapped in the passenger seat of my body, watching as they used me to collect more grief, more memories, more souls to add to the Chorus.
+
+Over the next three days, they visited seven of my clients. Each time, the newest member of the Chorus took control to convince their loved ones to hand over more grief-soaked items. Some were suspicious, but most were so desperate to believe they were communicating with their dead that they did whatever we asked.
+
+The pattern remained the same. My body would show up unannounced. My voice would say things only the dead person could know. My hands would take whatever they offered—journals, photographs, wedding rings, even clothing. And then my mouth would consume them, adding each new voice to the Chorus.
+
+With each new object I consumed against my will, the Chorus grew stronger. I felt myself shrinking, compressed into a smaller and smaller corner of my mind. The nightmare was consuming me, becoming more real with each passing hour. By the fourth day, I only got control for minutes at a time, usually when they were sleeping.
+
+During these brief windows, I tried everything to fight back—pain, alcohol, even smashing my head against the wall. Nothing worked. They just laughed and took back control, their voices overlapping in a discord of mockery.
+
+The only time they let me surface was when they needed me to know something. Like tonight, as my body lay on my bed, staring at the ceiling with eyes that no longer belonged to me.
+
+“We’re going to the cemetery tomorrow,” explained the first voice, my cousin’s mother. “We’ve decided it’s time to expand our operation.”
+
+“What do you mean?” I thought at them.
+
+“Fresh grief is the sweetest,” said another voice. “We’re going to find those in mourning and offer our services directly.”
+
+“No,” I thought. “I won’t let you.”
+
+They laughed, a cacophony of unique tones all using my vocal cords. “You don’t have a choice anymore. You’re just the vessel now.”
+
+And I realized they were right. I’d been so focused on fighting for control that I hadn’t considered the alternative. Maybe I couldn’t drive anymore, but I could still crash the car.
+
+While they debated their plans, I reached deep inside myself, to the place where my own grief lived. Not their grief—mine. The pain I’d been running from my whole life.
+
+I found the memory of my father’s death—the overdose I discovered when I was fourteen. My mother’s suicide two years later. The friend who died in my apartment while I was out buying more drugs for us. All the grief I’d never processed, never acknowledged, never consumed.
+
+I pulled it up like poison from a well, and before the Chorus realized what I was doing, I turned it on them.
+
+Grief is a living thing. It grows, changes, evolves. And when you feed it, it gets stronger.
+
+My grief flooded through the mental space the Chorus occupied. As the grief-feeding entities touched them, they screamed—entities unfamiliar with grief themselves. They’d only been the echoes, the impressions left behind. Never had they been the source.
+
+“Stop!” they shrieked as my grief engulfed them.
+
+“You wanted grief,” I told them. “Here it is. All you can eat.”
+
+I forced every painful memory through my consciousness—every loss, every regret, every moment of despair I’d ever experienced. I’d spent my life running from these feelings, but now I embraced them. They were my weapons.
+
+The Chorus splintered under the assault. Some voices faded altogether. Others fragmented into whispers. A few of the strongest pushed back, trying to regain control, but the assault weakened them.
+
+For the first time in days, I moved my hand when I wanted to. I dragged myself to the bathroom, teeth clenched against the battle still raging in my mind. In the mirror, my face was gaunt, eyes bloodshot. I looked like I’d aged a decade.
+
+But they were my eyes again. At least for now.
+
+“This isn’t over,” hissed one of the remaining voices. “We’ll wait. We’ll grow stronger again.”
+
+“No,” I said aloud, my voice hoarse but my own. “You won’t.”
+
+I opened the medicine cabinet and removed a pocket knife. The one my grandfather gave me before he died. The one object I’d never consumed despite its grief potential, because it was too precious.
+
+I put it in my mouth.
+
+Cold metal touched my tongue. I bit down, feeling it dissolve. But this time, instead of swallowing the grief, I focused on my grandfather’s love. The pride in his eyes when he gave me this knife. How he taught me to whittle. Wonderful memories accompanied the pain.
+
+The knife dissolved into a burst of emotion—not just grief, but joy, love, pride, nostalgia.
+
+And I realized my mistake all these years. Grief? It’s not the pain that destroys you. It’s all that love suddenly homeless, pounding on your ribcage, demanding somewhere to exist. And by consuming only the pain, I’d been creating these hungry ghosts, these fragments of people composed of sorrow.
+
+I opened my mouth, ready to tell them this revelation, but there was no response. The Chorus had gone silent.
+
+For now, at least.
+
+The next morning, I purged my apartment of all the grief-objects I’d collected over the years. Not by eating them—I’d never do that again—but by returning them to the families they belonged to. Some people were angry when I showed up at their doors. Others were confused. A few even begged me to take their grief back. I couldn’t. I wouldn’t.
+
+Each returned object lifted a weight from me. With every tearful conversation, every awkward explanation, every apology, the voices in my head grew fainter. Not gone completely—I could still hear them sometimes, especially at night—but more like memories than invaders.
+
+I thought of them not as the people they once were, but as wounds that needed healing—both theirs and mine.
+
+For the first time in months, I slept without the old nightmare. The terror of being trapped in my own body had lost its power over me, not because it wasn’t frightening anymore, but because I’d lived through the real thing and survived. I’d faced my worst fear and come out the other side.
+
+I stopped taking clients, moved to a different neighborhood, and changed my phone number. But people still found me, desperate for relief from their pain. Instead of eating their grief, I listened to their stories. Sometimes that was enough. Sometimes it wasn’t. But it was honest work, at least.
+
+A week after my liberation, a man brought me his daughter’s teddy bear. Cancer. She was seven.
+
+“Can you take it away?” he asked, tears streaming down his face. “I can’t live with this pain.”
+
+I sat with him for hours as he talked about her. Her favorite ice cream flavor. The way she insisted on wearing mismatched socks. How brave she was at the end.
+
+Before he left, I told him the truth, that grief is just love with nowhere to go. That the pain he felt was the other side of how much he loved her. That healing doesn’t mean forgetting.
+
+“Keep the bear,” I said. “She loved it, and you loved her. Let it hurt for now. Eventually, it’ll hurt less, but you’ll still have the love.”
+
+As he walked away clutching the bear, I felt something shift inside me. A few more voices in the Chorus faded, replaced by a peaceful silence.
+
+I still don’t know exactly what I am or how this strange ability works. But I know what I’m not anymore.
+
+I’m not a grief eater. I’m just someone who’s learning, finally, to digest my own.


### PR DESCRIPTION
## Problem

Gemini API provides support to cache large context (e.g. system instruction or conversation history) to reduce costs and improve performance for repeated API calls. Currently `gemini-rust` lacks support of this API.

https://ai.google.dev/api/caching
https://ai.google.dev/gemini-api/docs/caching?lang=python

## Design notes / implementation details

1. Model of the cache must be equal of model of the client, so I've made model of cache non-configurable.
2. Documentation proposing to use single structure [CachedContext](https://ai.google.dev/api/caching#CachedContent) for creating request / response, making some fields optional; I split this structure into multiple.
3. Explicit caching has lower limit of cache size, so in order to create usable example I've added small story that used as context data.

## Plan

- [x] Caching support.
- [x] Example.
- [x] Documentation.
- [x] Changelog.
- [x] Readme.
- [x] Tests.