### PR TITLE
Fix output_dimensionality method signature in EmbedBuilder

### DIFF
--- a/src/embed_builder.rs
+++ b/src/embed_builder.rs
@@ -61,9 +61,8 @@ impl EmbedBuilder {
     }
 
     /// Specify output_dimensionality. If set, excessive values in the output embedding are truncated from the end
-    /// Supported by newer models since 2024 only !!
-    pub fn with_output_dimensionality(mut self, title: String) -> Self {
-        self.title = Some(title);
+    pub fn with_output_dimensionality(mut self, output_dimensionality: i32) -> Self {
+        self.output_dimensionality = Some(output_dimensionality);
         self
     }
 


### PR DESCRIPTION
This pull request updates the `with_output_dimensionality` method in the `EmbedBuilder` implementation to improve its API and ensure it properly reflects its intended functionality.

API improvements:

* Changed the parameter of `EmbedBuilder::with_output_dimensionality` from a `String` (previously named `title`) to an `i32` named `output_dimensionality`, and updated the method to set the `output_dimensionality` field instead of `title`. This makes the method signature and behavior more accurate and intuitive for specifying the output dimensionality.