### PR TITLE
Add thought_signature support to Part::Text and related methods

### DIFF
--- a/THOUGHT_SIGNATURE.md
+++ b/THOUGHT_SIGNATURE.md
@@ -20,6 +20,18 @@ pub struct FunctionCall {
 }
 ```
 
+### 1a. Part::Text Structure Update
+
+The `Part::Text` variant now includes an optional `thought_signature` field to support text responses with thought signatures:
+
+```rust
+Text {
+    text: String,
+    thought: Option<bool>,
+    thought_signature: Option<String>,  // New field
+}
+```
+
 ### 2. New Constructor Methods
 
 - `FunctionCall::new()` - Creates function call without thought signature (maintains backward compatibility)
@@ -50,7 +62,7 @@ FunctionCall {
 
 ### 4. New API Methods
 
-`GenerationResponse` adds methods to retrieve function calls with their thought signatures:
+`GenerationResponse` adds methods to retrieve function calls and text with their thought signatures:
 
 ```rust
 // Get function calls and their corresponding thought signatures
@@ -61,6 +73,28 @@ for (function_call, thought_signature) in function_calls_with_thoughts {
         println!("Thought Signature: {}", signature);
     }
 }
+
+// Get text parts with their thought signatures
+let text_with_thoughts = response.text_with_thoughts();
+for (text, is_thought, thought_signature) in text_with_thoughts {
+    println!("Text: {}", text);
+    println!("Is thought: {}", is_thought);
+    if let Some(signature) = thought_signature {
+        println!("Thought Signature: {}", signature);
+    }
+}
+```
+
+### 5. New Content Creation Methods
+
+`Content` adds methods to create content with thought signatures:
+
+```rust
+// Create text content with thought signature
+let content = Content::text_with_thought_signature("Response text", "signature123");
+
+// Create thought content with thought signature
+let thought_content = Content::thought_with_signature("Thinking process", "signature456");
 ```
 
 ## Usage Examples
@@ -115,7 +149,9 @@ conversation.contents.push(model_content);
 // Continue conversation...
 ```
 
-## API Response Example
+## API Response Examples
+
+### Function Call with thoughtSignature
 
 When Gemini 2.5 Pro makes function calls, the response will include `thoughtSignature`:
 
@@ -139,6 +175,38 @@ When Gemini 2.5 Pro makes function calls, the response will include `thoughtSign
       }
     }
   ]
+}
+```
+
+### Text Response with thoughtSignature
+
+Text responses can also include `thoughtSignature` fields:
+
+```json
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**Okay, here's what I'm thinking:**\n\nThe user wants me to show them the functions available...",
+            "thought": true
+          },
+          {
+            "text": "The following functions are available in the environment: `chat.get_message_count()`",
+            "thoughtSignature": "Cs4BA.../Yw="
+          }
+        ],
+        "role": "model"
+      }
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 36,
+    "candidatesTokenCount": 18,
+    "totalTokenCount": 96,
+    "thoughtsTokenCount": 42
+  }
 }
 ```
 

--- a/examples/curl_equivalent.rs
+++ b/examples/curl_equivalent.rs
@@ -43,6 +43,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let text_part = Part::Text {
         text: "Explain how AI works in a few words".to_string(),
         thought: None,
+        thought_signature: None,
     };
 
     let content = Content {

--- a/examples/curl_google_search.rs
+++ b/examples/curl_google_search.rs
@@ -33,6 +33,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let text_part = Part::Text {
         text: "What is the current Google stock price?".to_string(),
         thought: None,
+        thought_signature: None,
     };
 
     let content = Content {

--- a/examples/multi_speaker_tts.rs
+++ b/examples/multi_speaker_tts.rs
@@ -97,7 +97,11 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
                                 }
                             }
                             // Display any text content
-                            Part::Text { text, thought } => {
+                            Part::Text {
+                                text,
+                                thought,
+                                thought_signature: _,
+                            } => {
                                 if thought.unwrap_or(false) {
                                     println!("💭 Model thought: {}", text);
                                 } else {

--- a/examples/simple_speech_generation.rs
+++ b/examples/simple_speech_generation.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             },
                             // Display any text content
-                            Part::Text { text, thought } => {
+                            Part::Text { text, thought, thought_signature: _ } => {
                                 if thought.unwrap_or(false) {
                                     println!("💭 Thought: {}", text);
                                 } else {

--- a/examples/text_thought_signature_example.rs
+++ b/examples/text_thought_signature_example.rs
@@ -1,0 +1,152 @@
+/// Example demonstrating text responses with thoughtSignature support
+///
+/// This example shows how to handle text responses that include thought signatures,
+/// as seen in the Gemini 2.5 Flash API response format.
+use gemini_rust::{Content, GenerationResponse, Part};
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Text with thoughtSignature Example ===\n");
+
+    // Simulate an API response similar to the one you provided
+    let api_response = json!({
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "text": "**Okay, here's what I'm thinking:**\n\nThe user wants me to show them the functions available. I need to figure out what functions are accessible to me in this environment.",
+                            "thought": true
+                        },
+                        {
+                            "text": "The following functions are available in the environment: `chat.get_message_count()`",
+                            "thoughtSignature": "Cs4BA.../Yw="
+                        }
+                    ],
+                    "role": "model"
+                },
+                "finishReason": "STOP",
+                "index": 0
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 36,
+            "candidatesTokenCount": 18,
+            "totalTokenCount": 96,
+            "promptTokensDetails": [
+                {
+                    "modality": "TEXT",
+                    "tokenCount": 36
+                }
+            ],
+            "thoughtsTokenCount": 42
+        },
+        "modelVersion": "gemini-2.5-flash",
+        "responseId": "gIC..."
+    });
+
+    // Parse the response
+    let response: GenerationResponse = serde_json::from_value(api_response)?;
+
+    println!("📋 Parsed API Response:");
+    println!(
+        "Model Version: {}",
+        response
+            .model_version
+            .as_ref()
+            .unwrap_or(&"Unknown".to_string())
+    );
+
+    // Display usage metadata
+    if let Some(usage) = &response.usage_metadata {
+        println!("\n📊 Token Usage:");
+        println!("  Prompt tokens: {}", usage.prompt_token_count);
+        println!(
+            "  Response tokens: {}",
+            usage.candidates_token_count.unwrap_or(0)
+        );
+        println!("  Total tokens: {}", usage.total_token_count);
+        if let Some(thinking_tokens) = usage.thoughts_token_count {
+            println!("  Thinking tokens: {}", thinking_tokens);
+        }
+    }
+
+    // Extract text parts with thought signatures using the new method
+    println!("\n💭 Text Parts with Thought Analysis:");
+    let text_with_thoughts = response.text_with_thoughts();
+
+    for (i, (text, is_thought, thought_signature)) in text_with_thoughts.iter().enumerate() {
+        println!("\n--- Part {} ---", i + 1);
+        println!("Is thought: {}", is_thought);
+        println!("Has thought signature: {}", thought_signature.is_some());
+
+        if let Some(signature) = thought_signature {
+            println!("Thought signature: {}", signature);
+            println!("Signature length: {} characters", signature.len());
+        }
+
+        println!("Text content: {}", text);
+    }
+
+    // Demonstrate creating content with thought signatures
+    println!("\n🔧 Creating Content with Thought Signatures:");
+
+    let custom_content = Content::text_with_thought_signature(
+        "This is a custom response with a thought signature",
+        "custom_signature_abc123",
+    );
+
+    let custom_thought = Content::thought_with_signature(
+        "This represents the model's thinking process",
+        "thinking_signature_def456",
+    );
+
+    println!("Custom content JSON:");
+    println!("{}", serde_json::to_string_pretty(&custom_content)?);
+
+    println!("\nCustom thought JSON:");
+    println!("{}", serde_json::to_string_pretty(&custom_thought)?);
+
+    // Show how this would be used in multi-turn conversation context
+    println!("\n🔄 Multi-turn Conversation Context:");
+    println!("In a multi-turn conversation, you would include these parts");
+    println!("with their thought signatures to maintain context:");
+
+    // Extract the original parts for context preservation
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(parts) = &candidate.content.parts {
+            for (i, part) in parts.iter().enumerate() {
+                match part {
+                    Part::Text {
+                        text: _,
+                        thought,
+                        thought_signature,
+                    } => {
+                        println!(
+                            "\nPart {}: {} text{}",
+                            i + 1,
+                            if *thought == Some(true) {
+                                "Thought"
+                            } else {
+                                "Regular"
+                            },
+                            if thought_signature.is_some() {
+                                " with signature"
+                            } else {
+                                ""
+                            }
+                        );
+
+                        if let Some(sig) = thought_signature {
+                            println!("  ↳ Preserve signature: {}...", &sig[..10.min(sig.len())]);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    println!("\n✅ Example completed successfully!");
+    Ok(())
+}

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -170,6 +170,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 parts: Some(vec![gemini_rust::Part::Text {
                     text: final_response.text(),
                     thought: None,
+                    thought_signature: None,
                 }]),
                 role: Some(gemini_rust::Role::Model),
             };


### PR DESCRIPTION
- Updated Part::Text structure to include an optional thought_signature field.
- Modified GenerationResponse to handle thought signatures in text parts.
- Introduced new methods for creating content with thought signatures.
- Added tests for deserialization and content creation with thought signatures.
- Created example demonstrating text responses with thought signatures.