### PR TITLE
Failed generation handling.

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -396,6 +396,7 @@ pub struct CitationSource {
 #[serde(rename_all = "camelCase")]
 pub struct Candidate {
     /// The content of the candidate
+    #[serde(default)]
     pub content: Content,
     /// The safety ratings for the candidate
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Problem 

If a candidate's generation is stopped due to an error (`finish_reason` is not `None`), it might lack the `content` field.

This contradicts documentation, but I'm no longer surprised by it.

Documentation:
https://ai.google.dev/api/generate-content#candidate

## Solution

Given that `Content` implements `Default`, I've made it substitute its default value in situations where it's absent in the JSON.

It would be more correct to use an enum here, but I can't imagine what other undocumented behavior might occur.