### PR TITLE
Model deserialization improvements.

### DIFF
--- a/src/batch/model.rs
+++ b/src/batch/model.rs
@@ -4,6 +4,7 @@ use time::OffsetDateTime;
 
 use crate::common::serde::*;
 use crate::generation::{GenerateContentRequest, GenerationResponse};
+use crate::Model;
 
 /// Batch file request line JSON representation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -109,7 +110,7 @@ pub struct BatchMetadata {
     #[serde(rename = "@type")]
     pub type_annotation: String,
     /// Model used for the batch
-    pub model: String,
+    pub model: Model,
     /// Display name of the batch
     pub display_name: String,
     /// Creation time

--- a/src/cache/builder.rs
+++ b/src/cache/builder.rs
@@ -119,7 +119,7 @@ impl CacheBuilder {
 
     /// Execute the cache creation request.
     pub async fn execute(self) -> Result<CachedContentHandle, Error> {
-        let model = self.client.model.to_string();
+        let model = self.client.model.clone();
         let expiration = self.expiration.ok_or(Error::MissingExpiration)?;
 
         let cached_content = CreateCachedContentRequest {

--- a/src/cache/model.rs
+++ b/src/cache/model.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
 use crate::models::Content;
-use crate::{Tool, ToolConfig};
+use crate::{Model, Tool, ToolConfig};
 
 /// Cached content resource returned by the API (with all server-provided fields).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -13,8 +13,7 @@ pub struct CachedContent {
     pub name: String,
 
     /// The name of the model used for cached content.
-    /// Format: models/{model}
-    pub model: String,
+    pub model: Model,
 
     /// Output only. Creation time of the cached content.
     #[serde(with = "time::serde::rfc3339")]
@@ -114,8 +113,7 @@ pub struct CreateCachedContentRequest {
     pub display_name: Option<String>,
 
     /// Required. The name of the model to use for cached content.
-    /// Format: models/{model}
-    pub model: String,
+    pub model: Model,
 
     /// Optional. Input only. Immutable. The content to cache.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -154,7 +152,7 @@ pub struct CachedContentSummary {
     pub name: String,
 
     /// The name of the model used for cached content.
-    pub model: String,
+    pub model: Model,
 
     /// Creation time of the cached content.
     #[serde(with = "time::serde::rfc3339")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,7 +18,7 @@ use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue},
     Client, ClientBuilder, Response,
 };
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::json;
 use snafu::{ResultExt, Snafu};
 use std::{
@@ -35,13 +35,18 @@ static DEFAULT_BASE_URL: LazyLock<Url> = LazyLock::new(|| {
         .expect("unreachable error: failed to parse default base URL")
 });
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum Model {
     #[default]
+    #[serde(rename = "models/gemini-2.5-flash")]
     Gemini25Flash,
+    #[serde(rename = "models/gemini-2.5-flash-lite")]
     Gemini25FlashLite,
+    #[serde(rename = "models/gemini-2.5-pro")]
     Gemini25Pro,
+    #[serde(rename = "models/text-embedding-004")]
     TextEmbedding004,
+    #[serde(untagged)]
     Custom(String),
 }
 

--- a/src/embedding/builder.rs
+++ b/src/embedding/builder.rs
@@ -69,7 +69,7 @@ impl EmbedBuilder {
     /// Execute the request
     pub async fn execute(self) -> Result<ContentEmbeddingResponse, ClientError> {
         let request = EmbedContentRequest {
-            model: self.client.model.to_string(),
+            model: self.client.model.clone(),
             content: self.contents.first().expect("No content set").clone(),
             task_type: self.task_type,
             title: self.title,
@@ -87,7 +87,7 @@ impl EmbedBuilder {
 
         for content in self.contents {
             let request = EmbedContentRequest {
-                model: self.client.model.to_string(),
+                model: self.client.model.clone(),
                 content: content.clone(),
                 task_type: self.task_type.clone(),
                 title: self.title.clone(),

--- a/src/embedding/model.rs
+++ b/src/embedding/model.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::Content;
+use crate::{Content, Model};
 
 /// Text embedding representation
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -28,7 +28,7 @@ pub struct BatchContentEmbeddingResponse {
 #[serde(rename_all = "camelCase")]
 pub struct EmbedContentRequest {
     /// The specified embedding model
-    pub model: String,
+    pub model: Model,
     /// The chunks content to generate embeddings
     pub content: Content,
     /// The embedding task type (optional)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,28 @@
-use crate::{FinishReason, FunctionCall, GenerationResponse, Part};
+use crate::{FinishReason, FunctionCall, GenerationResponse, Model, Part};
+use serde::{Deserialize, Serialize};
 use serde_json::json;
+
+#[test]
+fn test_model_deserialization() {
+    #[derive(Serialize, Deserialize)]
+    struct Response {
+        model: Model,
+    }
+
+    let response = Response {
+        model: Model::Custom("models/custom_gemini_model".to_string()),
+    };
+    let serialized = serde_json::to_string(&response).unwrap();
+    let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.model, response.model);
+
+    let response = Response {
+        model: Model::Gemini25Flash,
+    };
+    let serialized = serde_json::to_string(&response).unwrap();
+    let deserialized: Response = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.model, response.model);
+}
 
 #[test]
 fn test_thought_signature_deserialization() {


### PR DESCRIPTION
These changes are not urgent, so I suggest not merging them until the next minor release (they break public API).

## Description

These changes allow for the use of the `Model` enum instead of a string.

## Plan

- [x] Replace all `model: String` occurrences.
- [x] Test.
  - [x] Run some examples (I did run not all of them, but behavior should be the same).
  - [x] Add unit tests.
  - [x] Use in production environment.