### PR TITLE
Initial tracing implementation.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ info!("starting content generation");  // ✓
 info!("Starting content generation");  // ✗
 ```
 
-**Field naming**: Use dot notation and descriptive boolean flags
+**Field naming**: Use dot notation and descriptive boolean flags. Group related fields with common prefixes.
 ```rust
 info!(status.code = 200, file.size = 1024, tools.present = true, "request completed");
 ```
@@ -35,6 +35,8 @@ info!(status.code = 200, file.size = 1024, tools.present = true, "request comple
 - Strings: `field = value`
 - Errors: `error = %err`
 - Complex types: `field = ?value`
+- Optional types: Use native support (`field = optional_value`). Do not use `.unwrap_or("none")` or similar constructs; `tracing` handles `Option` types automatically.
+- Optional enums: Convert to `Option<String>` for better queryability. For enums deriving `strum::AsRefStr`, use the more readable `field = enum_opt.as_ref().map(AsRef::<str>::as_ref)`. For other types, use `field = enum_opt.as_ref().map(|t| format!("{t:?}"))`. This transforms `Some(MyEnum::Variant)` into `Some("Variant")`, which is easier to search in logs.
 
 **Span placeholders**: Define fields in `#[instrument]` and populate with `Span::current().record()`
 ```rust
@@ -47,11 +49,67 @@ async fn process(&self) -> Result<(), Error> {
 }
 ```
 
+**Instrumentation patterns**: Use descriptive field names with logical grouping:
+```rust
+#[instrument(skip_all, fields(
+    model,
+    messages.parts.count = request.contents.len(),
+    tools.present = request.tools.is_some(),
+    system.instruction.present = request.system_instruction.is_some(),
+    cached.content.present = request.cached_content.is_some(),
+    task.type = request.task_type.as_ref().map(|t| format!("{:?}", t)),
+    task.title = request.title,
+    task.output.dimensionality = request.output_dimensionality,
+    batch.size = request.requests.len(),
+    batch.display_name = request.batch.display_name,
+    operation.name = name,
+    page.size = page_size,
+    page.token.present = page_token.is_some(),
+    file.name = name,
+    file.size = file_bytes.len(),
+    mime.type = mime_type.to_string(),
+    file.display_name = display_name.as_deref(),
+))]
+```
+
 **Log levels**: `debug!` for details, `info!` for status, `warn!` for issues, `error!` for failures.
 
-### Example
+### Examples
 
 ```rust
 info!(batch_name = "my-batch", requests.count = 10, "batch started");
 error!(error = %err, model = "gemini-2.5-flash", "generation failed");
+
+// Content generation instrumentation
+#[instrument(skip_all, fields(
+    model,
+    messages.parts.count = request.contents.len(),
+    tools.present = request.tools.is_some(),
+    system.instruction.present = request.system_instruction.is_some(),
+    cached.content.present = request.cached_content.is_some(),
+))]
+
+// Embedding instrumentation with enum handling
+#[instrument(skip_all, fields(
+    model,
+    task.type = request.task_type.as_ref().map(|t| format!("{:?}", t)),
+    task.title = request.title,
+    task.output.dimensionality = request.output_dimensionality,
+))]
+
+// File operations instrumentation
+#[instrument(skip_all, fields(
+    file.name = name,
+))]
+
+// Batch operations instrumentation
+#[instrument(skip_all, fields(
+    operation.name = name,
+))]
+
+// Pagination instrumentation
+#[instrument(skip_all, fields(
+    page.size = page_size,
+    page.token.present = page_token.is_some(),
+))]
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Agent Development Guide
+
+This document provides guidelines for developing agents and applications using the gemini-rust library.
+
+## Logging
+
+The gemini-rust library uses structured logging with the `tracing` crate for comprehensive observability.
+
+### Setup
+
+Initialize tracing in your main function:
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    // Your code here
+}
+```
+
+### Conventions
+
+**Message formatting**: Use lowercase messages
+```rust
+info!("starting content generation");  // ✓
+info!("Starting content generation");  // ✗
+```
+
+**Field naming**: Use dot notation and descriptive boolean flags
+```rust
+info!(status.code = 200, file.size = 1024, tools.present = true, "request completed");
+```
+
+**Value formatting**:
+- Strings: `field = value`
+- Errors: `error = %err`
+- Complex types: `field = ?value`
+
+**Span placeholders**: Define fields in `#[instrument]` and populate with `Span::current().record()`
+```rust
+#[instrument(skip_all, fields(model, status.code))]
+async fn process(&self) -> Result<(), Error> {
+    Span::current().record("model", self.model.as_str());
+    debug!("processing request");
+    // ... operation
+    Span::current().record("status.code", 200);
+}
+```
+
+**Log levels**: `debug!` for details, `info!` for status, `warn!` for issues, `error!` for failures.
+
+### Example
+
+```rust
+info!(batch_name = "my-batch", requests.count = 10, "batch started");
+error!(error = %err, model = "gemini-2.5-flash", "generation failed");
+```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ mime_guess = "2.0"
 mime = "0.3"
 tokio = { version = "1", features = ["io-util"] }
 time = { version = "0.3", features = ["serde", "parsing", "formatting"] }
+tracing = "0.1.41"
 
 [dev-dependencies]
 display-error-chain = "0.2"
 tokio = { version = "^1.47", features = ["full"] }
+tracing-subscriber = "0.3.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,4 @@ strum_macros = "0.27"
 [dev-dependencies]
 display-error-chain = "0.2"
 tokio = { version = "^1.47", features = ["full"] }
-tracing-subscriber = "0.3.20"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ mime = "0.3"
 tokio = { version = "1", features = ["io-util"] }
 time = { version = "0.3", features = ["serde", "parsing", "formatting"] }
 tracing = "0.1.41"
+strum = { version = "0.26", features = ["derive"] }
+strum_macros = "0.26"
 
 [dev-dependencies]
 display-error-chain = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ mime = "0.3"
 tokio = { version = "1", features = ["io-util"] }
 time = { version = "0.3", features = ["serde", "parsing", "formatting"] }
 tracing = "0.1.41"
-strum = { version = "0.26", features = ["derive"] }
-strum_macros = "0.26"
+strum = { version = "0.27", features = ["derive"] }
+strum_macros = "0.27"
 
 [dev-dependencies]
 display-error-chain = "0.2"

--- a/README.md
+++ b/README.md
@@ -559,6 +559,8 @@ export GEMINI_API_KEY="your-api-key-here"
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
+For guidelines on developing agents and applications, see the [Agent Development Guide](AGENTS.md).
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -498,6 +498,19 @@ let client = GeminiBuilder::new(api_key)
     .build()?;
 ```
 
+## 🔍 Tracing and Telemetry
+
+The library is instrumented with the `tracing` crate to provide detailed telemetry data for monitoring and debugging. This allows you to gain deep insights into the library's performance and behavior.
+
+Key tracing features include:
+
+* **HTTP Request Tracing**: Captures detailed information about every API call, including HTTP method, URL, and response status, to help diagnose network-related issues.
+* **Token Usage Monitoring**: Records the number of prompt, candidate, and total tokens for each generation request, enabling cost analysis and optimization.
+* **Structured Logging**: Emits traces as structured events, compatible with modern log aggregation platforms like Elasticsearch, Datadog, and Honeycomb, allowing for powerful querying and visualization.
+* **Performance Metrics**: Provides timing information for each API request, allowing you to identify and address performance bottlenecks.
+
+To use these features, you will need to integrate a `tracing` subscriber into your application. For structured logging, it is recommended to use a JSON-based subscriber.
+
 ## 📚 Examples
 
 The repository includes comprehensive examples:

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,14 +1,33 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{
     Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, Part,
     PropertyDetails,
 };
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("GEMINI_API_KEY")?;
 
     // Create client

--- a/examples/batch_cancel.rs
+++ b/examples/batch_cancel.rs
@@ -10,6 +10,7 @@
 use gemini_rust::{Batch, BatchHandleError, BatchStatus, Gemini, Message};
 use std::{env, sync::Arc, time::Duration};
 use tokio::{signal, sync::Mutex};
+use tracing::{error, info, warn};
 
 /// Waits for the batch operation to complete by periodically polling its status.
 ///
@@ -42,6 +43,9 @@ pub async fn wait_for_completion(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
+
     // Get the API key from the environment
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
 
@@ -68,9 +72,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Build and start the batch
     let batch = batch_generate_content.execute().await?;
-    println!("Batch created successfully!");
-    println!("Batch Name: {}", batch.name());
-    println!("Press CTRL-C to cancel the batch operation...");
+    info!(batch_name = batch.name(), "batch created successfully");
+    info!("press ctrl-c to cancel the batch operation");
 
     // Wrap the batch in an Arc<Mutex<Option<Batch>>> to allow safe sharing
     let batch = Arc::new(Mutex::new(Some(batch)));
@@ -80,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cancel_task = tokio::spawn(async move {
         // Wait for CTRL-C signal
         signal::ctrl_c().await.expect("Failed to listen for CTRL-C");
-        println!("Received CTRL-C, canceling batch operation...");
+        info!("received ctrl-c, canceling batch operation");
 
         // Take the batch from the Option, leaving None.
         // The lock is released immediately after this block.
@@ -90,23 +93,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // Cancel the batch operation
             match batch.cancel().await {
                 Ok(()) => {
-                    println!("Batch canceled successfully!");
+                    info!("batch canceled successfully");
                 }
                 Err((batch, e)) => {
-                    println!("Failed to cancel batch: {}. Retrying...", e);
+                    warn!(error = %e, "failed to cancel batch, retrying");
                     // Retry once
                     match batch.cancel().await {
                         Ok(()) => {
-                            println!("Batch canceled successfully on retry!");
+                            info!("batch canceled successfully on retry");
                         }
                         Err((_, retry_error)) => {
-                            eprintln!("Failed to cancel batch even on retry: {}", retry_error);
+                            error!(error = %retry_error, "failed to cancel batch even on retry");
                         }
                     }
                 }
             }
         } else {
-            println!("Batch was already processed.");
+            info!("batch was already processed");
         }
     });
 
@@ -115,38 +118,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Wait for the batch to complete or be canceled
     if let Some(batch) = batch.lock().await.take() {
-        println!("Waiting for batch to complete or be canceled...");
+        info!("waiting for batch to complete or be canceled");
         match wait_for_completion(batch, Duration::from_secs(5)).await {
             Ok(final_status) => {
                 // Cancel task is no longer needed since batch completed
                 cancel_task.abort();
 
-                println!("Batch completed with status: {:?}", final_status);
+                info!(status = ?final_status, "batch completed");
 
-                // Print some details about the results
+                // Log details about the results
                 match final_status {
                     gemini_rust::BatchStatus::Succeeded { .. } => {
-                        println!("Batch succeeded!");
+                        info!("batch succeeded");
                     }
                     gemini_rust::BatchStatus::Cancelled => {
-                        println!("Batch was cancelled as requested.");
+                        info!("batch was cancelled as requested");
                     }
                     gemini_rust::BatchStatus::Expired => {
-                        println!("Batch expired.");
+                        warn!("batch expired");
                     }
                     _ => {
-                        println!("Batch finished with an unexpected status.");
+                        warn!("batch finished with unexpected status");
                     }
                 }
             }
             Err((batch, e)) => {
                 // This could happen if there was a network error while polling
-                println!("Error while waiting for batch completion: {}", e);
+                error!(error = %e, "error while waiting for batch completion");
 
                 // Try one more time to get the status
                 match batch.status().await {
-                    Ok(status) => println!("Current batch status: {:?}", status),
-                    Err(status_error) => println!("Error getting final status: {}", status_error),
+                    Ok(status) => info!(status = ?status, "current batch status"),
+                    Err(status_error) => {
+                        error!(error = %status_error, "error getting final status")
+                    }
                 }
             }
         }

--- a/examples/batch_delete.rs
+++ b/examples/batch_delete.rs
@@ -16,14 +16,33 @@
 //! cargo run --package gemini-rust --example batch_delete
 //! ```
 
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{BatchStatus, Gemini};
 use std::env;
+use std::process::ExitCode;
 use tracing::{info, warn};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get the API key from the environment
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
 

--- a/examples/batch_embedding.rs
+++ b/examples/batch_embedding.rs
@@ -1,14 +1,18 @@
 use gemini_rust::{Gemini, Model, TaskType};
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
+
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)
     let client = Gemini::with_model(api_key, Model::TextEmbedding004)
         .expect("unable to create Gemini API client");
 
-    println!("Sending batch embedding request to Gemini API...");
+    info!("sending batch embedding request to gemini api");
 
     // Simple text embedding
     let response = client
@@ -18,9 +22,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute_batch()
         .await?;
 
-    println!("Response: ");
+    info!(
+        embeddings_count = response.embeddings.len(),
+        "batch embedding completed"
+    );
+
     for (i, e) in response.embeddings.iter().enumerate() {
-        println!("|{}|: {:?}\n", i, e.values);
+        info!(
+            index = i,
+            embedding_length = e.values.len(),
+            first_values = ?&e.values[..5.min(e.values.len())],
+            "embedding result"
+        );
     }
 
     Ok(())

--- a/examples/batch_embedding.rs
+++ b/examples/batch_embedding.rs
@@ -1,11 +1,29 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, Model, TaskType};
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)

--- a/examples/batch_generate.rs
+++ b/examples/batch_generate.rs
@@ -13,6 +13,7 @@
 
 use gemini_rust::{Batch, BatchHandleError, BatchStatus, Gemini, Message};
 use std::time::Duration;
+use tracing::{error, info, warn};
 
 /// Waits for the batch operation to complete by periodically polling its status.
 ///
@@ -45,6 +46,9 @@ pub async fn wait_for_completion(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
+
     // Get the API key from the environment
     let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
 
@@ -72,52 +76,52 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?;
 
     // Print the batch information
-    println!("Batch created successfully!");
-    println!("Batch Name: {}", batch.name());
+    info!(batch_name = batch.name(), "batch created successfully");
 
     // Wait for the batch to complete
-    println!("Waiting for batch to complete...");
+    info!("waiting for batch to complete");
     match wait_for_completion(batch, Duration::from_secs(5)).await {
         Ok(final_status) => {
             // Print the final status
             match final_status {
                 BatchStatus::Succeeded { results } => {
-                    println!("Batch succeeded!");
+                    info!("batch succeeded");
                     for item in results {
                         match item.response {
                             Ok(response) => {
-                                println!("--- Response for Key {} ---", item.meta.key);
-                                println!("{}", response.text());
+                                info!(
+                                    key = item.meta.key,
+                                    response = response.text(),
+                                    "batch response"
+                                );
                             }
                             Err(error) => {
-                                println!("--- Error for Key {} ---", item.meta.key);
-                                println!("Code: {}, Message: {}", error.code, error.message);
+                                error!(
+                                    key = item.meta.key,
+                                    code = error.code,
+                                    message = error.message,
+                                    "batch error"
+                                );
                                 if let Some(details) = &error.details {
-                                    println!("Details: {}", details);
+                                    error!(details = ?details, "error details");
                                 }
                             }
                         }
                     }
                 }
                 BatchStatus::Cancelled => {
-                    println!("Batch was cancelled.");
+                    warn!("batch was cancelled");
                 }
                 BatchStatus::Expired => {
-                    println!("Batch expired.");
+                    warn!("batch expired");
                 }
                 _ => {
-                    println!(
-                        "Batch finished with an unexpected status: {:?}",
-                        final_status
-                    );
+                    warn!(status = ?final_status, "batch finished with unexpected status");
                 }
             }
         }
         Err((_batch, e)) => {
-            println!(
-                "Batch failed: {}. You can retry with the returned batch.",
-                e
-            );
+            error!(error = %e, "batch failed - you can retry with the returned batch");
             // Here you could retry: batch.wait_for_completion(Duration::from_secs(5)).await, etc.
         }
     }

--- a/examples/batch_generate.rs
+++ b/examples/batch_generate.rs
@@ -11,7 +11,9 @@
 //! cargo run --package gemini-rust --example batch_generate
 //! ```
 
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Batch, BatchHandleError, BatchStatus, Gemini, Message};
+use std::process::ExitCode;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
@@ -45,10 +47,26 @@ pub async fn wait_for_completion(
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get the API key from the environment
     let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
 

--- a/examples/batch_list.rs
+++ b/examples/batch_list.rs
@@ -11,16 +11,19 @@
 
 use futures::StreamExt;
 use gemini_rust::Gemini;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get the API key from the environment
     let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
 
     // Create a new Gemini client
     let gemini = Gemini::new(api_key).expect("unable to create Gemini API client");
 
-    println!("Listing all batch operations...");
+    info!("listing all batch operations");
 
     // List all batch operations using the stream
     let stream = gemini.list_batches(5); // page_size of 5
@@ -29,18 +32,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(result) = stream.next().await {
         match result {
             Ok(operation) => {
-                println!(
-                    "  - Batch: {}, State: {:?}, Created: {}",
-                    operation.name, operation.metadata.state, operation.metadata.create_time
+                info!(
+                    batch_name = operation.name,
+                    state = ?operation.metadata.state,
+                    created = %operation.metadata.create_time,
+                    "batch operation found"
                 );
             }
             Err(e) => {
-                eprintln!("Error fetching batch operation: {}", e);
+                error!(error = ?e, "error fetching batch operation");
             }
         }
     }
 
-    println!("\nFinished listing operations.");
+    info!("finished listing batch operations");
 
     Ok(())
 }

--- a/examples/batch_list.rs
+++ b/examples/batch_list.rs
@@ -9,14 +9,33 @@
 //! cargo run --package gemini-rust --example batch_list
 //! ```
 
+use display_error_chain::DisplayErrorChain;
 use futures::StreamExt;
 use gemini_rust::Gemini;
+use std::process::ExitCode;
 use tracing::{error, info};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get the API key from the environment
     let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY not set");
 

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -4,9 +4,12 @@ use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -24,12 +27,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Convert to base64
     let data = general_purpose::STANDARD.encode(&buffer);
 
-    println!("Image loaded: {}", image_path.display());
+    info!(image_path = ?image_path, file_size = buffer.len(), "image loaded and encoded to base64");
 
     // Create client
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
-    println!("--- Describe Image ---");
+    info!("starting image description request");
     let response = client
         .generate_content()
         .with_inline_data(data, "image/webp")
@@ -42,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Response: {}", response.text());
+    info!(response = response.text(), "image description received");
 
     Ok(())
 }

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -1,15 +1,34 @@
 use base64::{engine::general_purpose, Engine as _};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/cache_basic.rs
+++ b/examples/cache_basic.rs
@@ -1,4 +1,6 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, Model};
+use std::process::ExitCode;
 use std::time::Duration;
 use tracing::{error, info, warn};
 
@@ -6,10 +8,26 @@ use tracing::{error, info, warn};
 const GRIEF_EATER_STORY: &str = include_str!("../test_data/grief_eater.txt");
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key =
         std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable must be set");
 

--- a/examples/curl_equivalent.rs
+++ b/examples/curl_equivalent.rs
@@ -1,8 +1,11 @@
 use gemini_rust::{Content, Gemini, Part};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -26,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
     // Method 1: Using the high-level API (simplest approach)
-    println!("--- Method 1: Using the high-level API ---");
+    info!("method 1: using high-level api");
 
     let response = client
         .generate_content()
@@ -34,10 +37,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Response: {}", response.text());
+    info!(response = response.text(), "response received");
 
     // Method 2: Using Content directly to match the curl example exactly
-    println!("\n--- Method 2: Matching curl example structure exactly ---");
+    info!("method 2: matching curl example structure exactly");
 
     // Create a content part that matches the JSON in the curl example
     let text_part = Part::Text {
@@ -57,7 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     content_builder.contents.push(content);
     let response = content_builder.execute().await?;
 
-    println!("Response: {}", response.text());
+    info!(response = response.text(), "response received");
 
     Ok(())
 }

--- a/examples/curl_equivalent.rs
+++ b/examples/curl_equivalent.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, Gemini, Part};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/curl_google_search.rs
+++ b/examples/curl_google_search.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, Gemini, Part, Tool};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/curl_google_search.rs
+++ b/examples/curl_google_search.rs
@@ -1,12 +1,15 @@
 use gemini_rust::{Content, Gemini, Part, Tool};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
-    println!("--- Curl equivalent with Google Search tool ---");
+    info!("starting curl equivalent with google search tool example");
 
     // This is equivalent to the curl example:
     // curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GEMINI_API_KEY" \
@@ -52,7 +55,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let response = content_builder.execute().await?;
 
-    println!("Response: {}", response.text());
+    info!(
+        response = response.text(),
+        "google search response received"
+    );
 
     Ok(())
 }

--- a/examples/custom_base_url.rs
+++ b/examples/custom_base_url.rs
@@ -1,8 +1,11 @@
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
     // Using custom base URL
@@ -14,7 +17,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     )
     .expect("unable to create Gemini API client");
 
-    println!("Custom base URL client created successfully");
+    info!(
+        base_url = custom_base_url,
+        "custom base url client created successfully"
+    );
 
     let response = client_custom
         .generate_content()
@@ -28,7 +34,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Response: {}", response.text());
+    info!(
+        response = response.text(),
+        "response received from custom base url"
+    );
 
     Ok(())
 }

--- a/examples/custom_base_url.rs
+++ b/examples/custom_base_url.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
     // Using custom base URL

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,14 +1,18 @@
 use gemini_rust::{Gemini, Model, TaskType};
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
+
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)
     let client = Gemini::with_model(api_key, Model::TextEmbedding004)
         .expect("unable to create Gemini API client");
 
-    println!("Sending embedding request to Gemini API...");
+    info!("sending embedding request to gemini api");
 
     // Simple text embedding
     let response = client
@@ -18,7 +22,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Response: {:?}", response.embedding.values);
+    info!(
+        embedding_length = response.embedding.values.len(),
+        first_values = ?&response.embedding.values[..5.min(response.embedding.values.len())],
+        "embedding completed"
+    );
 
     Ok(())
 }

--- a/examples/embedding.rs
+++ b/examples/embedding.rs
@@ -1,11 +1,29 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, Model, TaskType};
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = std::env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -26,7 +26,13 @@ async fn do_main(api_key: &str) -> Result<(), ClientError> {
 #[tokio::main]
 async fn main() -> ExitCode {
     // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
     let api_key = std::env::var("GEMINI_API_KEY").expect("no gemini api key provided");
 

--- a/examples/files_lifecycle.rs
+++ b/examples/files_lifecycle.rs
@@ -1,15 +1,18 @@
 //! An example of uploading a file, downloading it, and verifying the content.
 use futures::TryStreamExt;
 use gemini_rust::Gemini;
+use tracing::{error, info};
 
 const TEST_CONTENT: &str = "Hello, world! This is a test file for Gemini-Rust.";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
     let api_key = std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY must be set");
     let gemini = Gemini::new(&api_key)?;
 
-    println!("Uploading a file with known content...");
+    info!("uploading a file with known content");
 
     // 1. Upload a file
     let file_handle = gemini
@@ -19,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .upload()
         .await?;
 
-    println!("File uploaded successfully: {}", file_handle.name());
+    info!(file_name = file_handle.name(), "file uploaded successfully");
 
     // 2. Find remote file
     let files = gemini.list_files(None).try_collect::<Vec<_>>().await?;
@@ -34,7 +37,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // 3. Assert that the byte size is identical
-    println!("\nVerifying file content...");
+    info!("verifying file content");
     assert_eq!(
         remote_file.get_file_meta().size_bytes.unwrap(),
         TEST_CONTENT.len() as i64,
@@ -42,10 +45,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // 4. Delete the file
-    println!("\nCleaning up by deleting the file...");
+    info!("cleaning up by deleting the file");
     match file_handle.delete().await {
-        Ok(_) => println!("File deleted successfully."),
-        Err((_, e)) => eprintln!("Failed to delete file: {}", e),
+        Ok(_) => info!("file deleted successfully"),
+        Err((_, e)) => error!(error = %e, "failed to delete file"),
     }
 
     Ok(())

--- a/examples/gemini_pro_example.rs
+++ b/examples/gemini_pro_example.rs
@@ -1,9 +1,12 @@
 use gemini_rust::Gemini;
 use std::env;
+use tracing::info;
 
 /// Example usage of Gemini API matching the curl example format
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Replace with your actual API key
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -38,8 +41,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    // Print the response
-    println!("Response: {}", response.text());
+    // Log the response
+    info!(response = response.text(), "gemini pro response received");
 
     Ok(())
 }

--- a/examples/gemini_pro_example.rs
+++ b/examples/gemini_pro_example.rs
@@ -1,12 +1,31 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 /// Example usage of Gemini API matching the curl example format
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Replace with your actual API key
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/generation_config.rs
+++ b/examples/generation_config.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/generation_config.rs
+++ b/examples/generation_config.rs
@@ -1,8 +1,11 @@
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -10,7 +13,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
     // Using the full generation config
-    println!("--- Using full generation config ---");
+    info!("starting generation config example with full config");
     let response1 = client
         .generate_content()
         .with_system_prompt("You are a helpful assistant.")
@@ -30,13 +33,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!(
-        "Response with high temperature (0.9):\n{}\n",
-        response1.text()
+    info!(
+        temperature = 0.9,
+        response = response1.text(),
+        "response with high temperature received"
     );
 
     // Using individual generation parameters
-    println!("--- Using individual generation parameters ---");
+    info!("starting generation config example with individual parameters");
     let response2 = client
         .generate_content()
         .with_system_prompt("You are a helpful assistant.")
@@ -46,13 +50,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!(
-        "Response with low temperature (0.2):\n{}\n",
-        response2.text()
+    info!(
+        temperature = 0.2,
+        response = response2.text(),
+        "response with low temperature received"
     );
 
     // Setting multiple parameters individually
-    println!("--- Setting multiple parameters individually ---");
+    info!("starting generation config example with multiple individual parameters");
     let response3 = client
         .generate_content()
         .with_system_prompt("You are a helpful assistant.")
@@ -64,9 +69,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!(
-        "Response with custom parameters and stop sequence:\n{}",
-        response3.text()
+    info!(
+        temperature = 0.7,
+        top_p = 0.9,
+        max_tokens = 150,
+        response = response3.text(),
+        "response with custom parameters and stop sequence received"
     );
 
     Ok(())

--- a/examples/google_search.rs
+++ b/examples/google_search.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, Tool};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/google_search.rs
+++ b/examples/google_search.rs
@@ -1,15 +1,18 @@
 use gemini_rust::{Gemini, Tool};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
     // Create client
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
-    println!("--- Google Search tool example ---");
+    info!("starting google search tool example");
 
     // Create a Google Search tool
     let google_search_tool = Tool::google_search();
@@ -22,7 +25,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Response: {}", response.text());
+    info!(
+        response = response.text(),
+        "google search response received"
+    );
 
     Ok(())
 }

--- a/examples/google_search_with_functions.rs
+++ b/examples/google_search_with_functions.rs
@@ -1,15 +1,34 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{
     Content, FunctionCall, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini,
     Message, PropertyDetails, Role, Tool,
 };
 use serde_json::json;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/image_editing.rs
+++ b/examples/image_editing.rs
@@ -2,11 +2,14 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use gemini_rust::Gemini;
 use std::env;
 use std::fs;
+use tracing::{info, warn};
 
 /// Image editing example using Gemini API
 /// This demonstrates how to edit existing images using text prompts
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -14,12 +17,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Gemini::with_model(api_key, "models/gemini-2.5-flash-image-preview".to_string())
         .expect("unable to create Gemini API client");
 
-    println!("🎨 Image Editing with Gemini");
-    println!("This example shows how to edit images using text descriptions.");
-    println!();
+    info!("starting image editing example with Gemini");
 
     // First, let's generate a base image to edit
-    println!("📸 Step 1: Generating a base image...");
+    info!("step 1: generating base image");
     let base_response = client
         .generate_content()
         .with_user_message(
@@ -39,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     base_image_data = Some(inline_data.data.clone());
                     let image_bytes = BASE64.decode(&inline_data.data)?;
                     fs::write("base_landscape.png", image_bytes)?;
-                    println!("✅ Base image saved as: base_landscape.png");
+                    info!(filename = "base_landscape.png", "base image saved");
                     break;
                 }
             }
@@ -49,16 +50,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let base_data = match base_image_data {
         Some(data) => data,
         None => {
-            println!("❌ Failed to generate base image");
+            warn!("failed to generate base image");
             return Ok(());
         }
     };
 
-    println!();
-    println!("🖌️  Step 2: Editing the image...");
+    info!("step 2: editing the image");
 
     // Example 1: Add elements to the image
-    println!("   Adding a red barn to the scene...");
+    info!("adding red barn to the scene");
     let edit_response1 = client
         .generate_content()
         .with_user_message(
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     save_generated_images(&edit_response1, "landscape_with_barn")?;
 
     // Example 2: Change the weather/atmosphere
-    println!("   Changing the scene to sunset...");
+    info!("changing scene to sunset");
     let edit_response2 = client
         .generate_content()
         .with_user_message(
@@ -89,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     save_generated_images(&edit_response2, "sunset_landscape")?;
 
     // Example 3: Style transfer
-    println!("   Converting to watercolor style...");
+    info!("converting to watercolor style");
     let edit_response3 = client
         .generate_content()
         .with_user_message(
@@ -104,13 +104,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     save_generated_images(&edit_response3, "watercolor_landscape")?;
 
-    println!();
-    println!("🎉 Image editing examples completed!");
-    println!("Check the generated files:");
-    println!("   - base_landscape.png (original)");
-    println!("   - landscape_with_barn_*.png (with added barn)");
-    println!("   - sunset_landscape_*.png (sunset version)");
-    println!("   - watercolor_landscape_*.png (watercolor style)");
+    info!("image editing examples completed - check generated files: base_landscape.png, landscape_with_barn_*.png, sunset_landscape_*.png, watercolor_landscape_*.png");
 
     Ok(())
 }
@@ -128,7 +122,7 @@ fn save_generated_images(
                 match part {
                     gemini_rust::Part::Text { text, .. } => {
                         if !text.trim().is_empty() {
-                            println!("   📝 Model says: {}", text.trim());
+                            info!(text = text.trim(), prefix = prefix, "model text response");
                         }
                     }
                     gemini_rust::Part::InlineData { inline_data } => {
@@ -137,10 +131,10 @@ fn save_generated_images(
                             Ok(image_bytes) => {
                                 let filename = format!("{}_{}.png", prefix, image_count);
                                 fs::write(&filename, image_bytes)?;
-                                println!("   ✅ Edited image saved as: {}", filename);
+                                info!(filename = filename, prefix = prefix, "edited image saved");
                             }
                             Err(e) => {
-                                println!("   ❌ Failed to decode image: {}", e);
+                                warn!(error = ?e, prefix = prefix, "failed to decode image");
                             }
                         }
                     }
@@ -151,7 +145,7 @@ fn save_generated_images(
     }
 
     if image_count == 0 {
-        println!("   ⚠️  No images were generated for this edit");
+        warn!(prefix = prefix, "no images were generated for this edit");
     }
 
     Ok(())

--- a/examples/image_editing.rs
+++ b/examples/image_editing.rs
@@ -1,15 +1,34 @@
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use std::env;
 use std::fs;
+use std::process::ExitCode;
 use tracing::{info, warn};
 
 /// Image editing example using Gemini API
 /// This demonstrates how to edit existing images using text prompts
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/image_generation.rs
+++ b/examples/image_generation.rs
@@ -1,15 +1,34 @@
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
 use std::fs;
+use std::process::ExitCode;
 use tracing::{info, warn};
 
 /// Example of using Gemini API for image generation (text-to-image)
 /// This example demonstrates how to generate images using the Gemini 2.5 Flash Image Preview model
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/mp4_describe.rs
+++ b/examples/mp4_describe.rs
@@ -2,16 +2,35 @@
 // This example sends the mp4 video content to Gemini API and asks AI to describe the video.
 
 use base64::{engine::general_purpose, Engine as _};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, Gemini};
 use std::env;
 use std::fs::File;
 use std::io::Read;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Read mp4 video file
     info!("reading video file: examples/sample.mp4");
     let mut file = File::open("examples/sample.mp4")?;

--- a/examples/multi_speaker_tts.rs
+++ b/examples/multi_speaker_tts.rs
@@ -2,9 +2,12 @@ use base64::{engine::general_purpose, Engine as _};
 use gemini_rust::{Gemini, GenerationConfig, Part, SpeakerVoiceConfig, SpeechConfig};
 use std::fs::File;
 use std::io::Write;
+use tracing::{error, info};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Load API key from environment variable
     let api_key =
         std::env::var("GEMINI_API_KEY").expect("Please set GEMINI_API_KEY environment variable");
@@ -13,8 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Gemini::with_model(api_key, "models/gemini-2.5-flash-preview-tts".to_string())
         .expect("unable to create Gemini API client");
 
-    println!("🎭 Gemini Multi-Speaker Speech Generation Example");
-    println!("Generating multi-speaker audio from dialogue...\n");
+    info!("starting gemini multi-speaker speech generation example");
 
     // Create multi-speaker configuration
     let speakers = vec![
@@ -50,7 +52,7 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
         .await
     {
         Ok(response) => {
-            println!("✅ Multi-speaker speech generation completed!");
+            info!("multi-speaker speech generation completed");
 
             // Check if we have candidates
             for (i, candidate) in response.candidates.iter().enumerate() {
@@ -131,7 +133,7 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
             }
         }
         Err(e) => {
-            eprintln!("❌ Error generating multi-speaker speech: {}", e);
+            error!(error = ?e, "error generating multi-speaker speech");
             eprintln!("\n💡 Troubleshooting tips:");
             eprintln!("   1. Make sure GEMINI_API_KEY environment variable is set");
             eprintln!("   2. Verify you have access to the Gemini TTS model");

--- a/examples/multi_speaker_tts.rs
+++ b/examples/multi_speaker_tts.rs
@@ -1,13 +1,32 @@
 use base64::{engine::general_purpose, Engine as _};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Part, SpeakerVoiceConfig, SpeechConfig};
 use std::fs::File;
 use std::io::Write;
+use std::process::ExitCode;
 use tracing::{error, info};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Load API key from environment variable
     let api_key =
         std::env::var("GEMINI_API_KEY").expect("Please set GEMINI_API_KEY environment variable");
@@ -62,7 +81,7 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
                             // Look for inline data with audio MIME type
                             Part::InlineData { inline_data } => {
                                 if inline_data.mime_type.starts_with("audio/") {
-                                    println!("📄 Found audio data: {}", inline_data.mime_type);
+                                    info!("📄 Found audio data: {}", inline_data.mime_type);
 
                                     // Decode base64 audio data
                                     match general_purpose::STANDARD.decode(&inline_data.data) {
@@ -74,26 +93,26 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
                                             match File::create(&filename) {
                                                 Ok(mut file) => {
                                                     if let Err(e) = file.write_all(&audio_bytes) {
-                                                        eprintln!(
+                                                        error!(
                                                             "❌ Error writing audio file: {}",
                                                             e
                                                         );
                                                     } else {
-                                                        println!(
+                                                        info!(
                                                             "💾 Multi-speaker audio saved as: {}",
                                                             filename
                                                         );
-                                                        println!("🎧 Play with: aplay {} (Linux) or afplay {} (macOS)", filename, filename);
-                                                        println!("👥 Features Alice (Puck voice) and Bob (Charon voice)");
+                                                        info!("🎧 Play with: aplay {} (Linux) or afplay {} (macOS)", filename, filename);
+                                                        info!("👥 Features Alice (Puck voice) and Bob (Charon voice)");
                                                     }
                                                 }
                                                 Err(e) => {
-                                                    eprintln!("❌ Error creating audio file: {}", e)
+                                                    error!("❌ Error creating audio file: {}", e)
                                                 }
                                             }
                                         }
                                         Err(e) => {
-                                            eprintln!("❌ Error decoding base64 audio: {}", e)
+                                            error!("❌ Error decoding base64 audio: {}", e)
                                         }
                                     }
                                 }
@@ -105,9 +124,9 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
                                 thought_signature: _,
                             } => {
                                 if thought.unwrap_or(false) {
-                                    println!("💭 Model thought: {}", text);
+                                    info!("💭 Model thought: {}", text);
                                 } else {
-                                    println!("📝 Generated text: {}", text);
+                                    info!("📝 Generated text: {}", text);
                                 }
                             }
                             _ => {
@@ -120,35 +139,35 @@ Alice: I couldn't agree more. It's remarkable how far AI-generated speech has co
 
             // Display usage metadata if available
             if let Some(usage_metadata) = &response.usage_metadata {
-                println!("\n📊 Usage Statistics:");
+                info!("📊 Usage Statistics:");
                 if let Some(prompt_tokens) = usage_metadata.prompt_token_count {
-                    println!("   Prompt tokens: {}", prompt_tokens);
+                    info!("   Prompt tokens: {}", prompt_tokens);
                 }
                 if let Some(total_tokens) = usage_metadata.total_token_count {
-                    println!("   Total tokens: {}", total_tokens);
+                    info!("   Total tokens: {}", total_tokens);
                 }
                 if let Some(thoughts_tokens) = usage_metadata.thoughts_token_count {
-                    println!("   Thinking tokens: {}", thoughts_tokens);
+                    info!("   Thinking tokens: {}", thoughts_tokens);
                 }
             }
         }
         Err(e) => {
             error!(error = ?e, "error generating multi-speaker speech");
-            eprintln!("\n💡 Troubleshooting tips:");
-            eprintln!("   1. Make sure GEMINI_API_KEY environment variable is set");
-            eprintln!("   2. Verify you have access to the Gemini TTS model");
-            eprintln!("   3. Check your internet connection");
-            eprintln!("   4. Ensure speaker names in dialogue match configured speakers");
-            eprintln!("   5. Make sure the model 'gemini-2.5-flash-preview-tts' supports multi-speaker TTS");
+            error!("💡 Troubleshooting tips:");
+            error!("   1. Make sure GEMINI_API_KEY environment variable is set");
+            error!("   2. Verify you have access to the Gemini TTS model");
+            error!("   3. Check your internet connection");
+            error!("   4. Ensure speaker names in dialogue match configured speakers");
+            error!("   5. Make sure the model 'gemini-2.5-flash-preview-tts' supports multi-speaker TTS");
         }
     }
 
-    println!("\n🎉 Example completed!");
-    println!("💡 Tips for multi-speaker TTS:");
-    println!("   • Use clear speaker names (Alice:, Bob:, etc.)");
-    println!("   • Configure voice for each speaker beforehand");
-    println!("   • Available voices: Puck, Charon, Kore, Fenrir, Aoede");
-    println!("   • Each speaker maintains consistent voice characteristics");
+    info!("🎉 Example completed!");
+    info!("💡 Tips for multi-speaker TTS:");
+    info!("   • Use clear speaker names (Alice:, Bob:, etc.)");
+    info!("   • Configure voice for each speaker beforehand");
+    info!("   • Available voices: Puck, Charon, Kore, Fenrir, Aoede");
+    info!("   • Each speaker maintains consistent voice characteristics");
 
     Ok(())
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,15 +1,33 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{
     Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini,
     GenerationConfig, Message, PropertyDetails, Role,
 };
 use std::env;
+use std::process::ExitCode;
 use tracing::{info, warn};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/simple_image_generation.rs
+++ b/examples/simple_image_generation.rs
@@ -2,11 +2,14 @@ use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
 use std::fs;
+use tracing::{info, warn};
 
 /// Simple image generation example
 /// This demonstrates the basic usage of Gemini's image generation capabilities
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -15,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Gemini::with_model(api_key, "models/gemini-2.5-flash-image-preview".to_string())
         .expect("unable to create Gemini API client");
 
-    println!("🎨 Generating image with Gemini...");
+    info!("starting image generation example");
 
     // Generate an image from text description
     let response = client
@@ -41,11 +44,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             for part in parts.iter() {
                 match part {
                     gemini_rust::Part::Text { text, .. } => {
-                        println!("📝 Model response: {}", text);
+                        info!(response = text, "model text response received");
                     }
                     gemini_rust::Part::InlineData { inline_data } => {
-                        println!("🖼️  Image generated!");
-                        println!("   MIME type: {}", inline_data.mime_type);
+                        info!(mime_type = inline_data.mime_type, "image generated");
 
                         // Decode and save the image
                         match BASE64.decode(&inline_data.data) {
@@ -53,15 +55,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 images_saved += 1;
                                 let filename = format!("robot_garden_{}.png", images_saved);
                                 fs::write(&filename, image_bytes)?;
-                                println!("✅ Image saved as: {}", filename);
+                                info!(filename = filename, "image saved successfully");
                             }
                             Err(e) => {
-                                println!("❌ Failed to decode image: {}", e);
+                                warn!(error = ?e, "failed to decode image");
                             }
                         }
                     }
                     _ => {
-                        println!("🔍 Other content type in response");
+                        info!("other content type found in response");
                     }
                 }
             }
@@ -69,12 +71,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if images_saved == 0 {
-        println!("⚠️  No images were generated. This might be due to:");
-        println!("   - Content policy restrictions");
-        println!("   - API limitations");
-        println!("   - Model configuration issues");
+        warn!("no images were generated - possible reasons: content policy restrictions, API limitations, or model configuration issues");
     } else {
-        println!("🎉 Successfully generated {} image(s)!", images_saved);
+        info!(
+            images_count = images_saved,
+            "image generation completed successfully"
+        );
     }
 
     Ok(())

--- a/examples/simple_image_generation.rs
+++ b/examples/simple_image_generation.rs
@@ -1,15 +1,34 @@
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;
 use std::fs;
+use std::process::ExitCode;
 use tracing::{info, warn};
 
 /// Simple image generation example
 /// This demonstrates the basic usage of Gemini's image generation capabilities
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/simple_speech_generation.rs
+++ b/examples/simple_speech_generation.rs
@@ -1,13 +1,32 @@
 use base64::{engine::general_purpose, Engine as _};
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Part, PrebuiltVoiceConfig, SpeechConfig, VoiceConfig};
 use std::fs::File;
 use std::io::Write;
+use std::process::ExitCode;
 use tracing::{error, info};
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Load API key from environment variable
     let api_key =
         std::env::var("GEMINI_API_KEY").expect("Please set GEMINI_API_KEY environment variable");

--- a/examples/simple_thought_signature.rs
+++ b/examples/simple_thought_signature.rs
@@ -1,14 +1,33 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{
     FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails,
     ThinkingConfig, Tool,
 };
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("GEMINI_API_KEY")?;
     let client = Gemini::pro(api_key)?;
 

--- a/examples/simple_thought_signature.rs
+++ b/examples/simple_thought_signature.rs
@@ -3,9 +3,12 @@ use gemini_rust::{
     ThinkingConfig, Tool,
 };
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
     let api_key = env::var("GEMINI_API_KEY")?;
     let client = Gemini::pro(api_key)?;
 
@@ -38,17 +41,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let function_calls_with_thoughts = response.function_calls_with_thoughts();
 
     for (function_call, thought_signature) in function_calls_with_thoughts {
-        println!("Function called: {}", function_call.name);
-        println!("Arguments: {}", function_call.args);
+        info!(function_name = function_call.name, args = ?function_call.args, "function called");
 
         if let Some(signature) = thought_signature {
-            println!("Thought signature present: {} characters", signature.len());
-            println!(
-                "Signature preview: {}...",
-                &signature[..50.min(signature.len())]
+            info!(
+                signature_length = signature.len(),
+                preview = &signature[..50.min(signature.len())],
+                "thought signature present"
             );
         } else {
-            println!("No thought signature");
+            info!("no thought signature");
         }
     }
 

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -18,6 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut stream = client
         .generate_content()
+        .with_thinking_budget(0)
         .with_system_prompt("You are a helpful, creative assistant.")
         .with_user_message("Write a short story about a robot who learns to feel emotions.")
         .execute_stream()

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -1,12 +1,31 @@
+use display_error_chain::DisplayErrorChain;
 use futures_util::TryStreamExt;
 use gemini_rust::Gemini;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -31,10 +50,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(chunk) = stream.try_next().await? {
         let chunk_text = chunk.text();
         full_response.push_str(&chunk_text);
-        print!("{}", chunk_text);
-        std::io::Write::flush(&mut std::io::stdout())?;
+        tracing::debug!(chunk = chunk_text, "received chunk");
     }
-    println!();
     info!(response = full_response, "streaming generation completed");
 
     // Multi-turn conversation

--- a/examples/structured_response.rs
+++ b/examples/structured_response.rs
@@ -1,13 +1,31 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use serde_json::json;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/test_api.rs
+++ b/examples/test_api.rs
@@ -1,12 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)

--- a/examples/test_api.rs
+++ b/examples/test_api.rs
@@ -1,14 +1,18 @@
 use gemini_rust::Gemini;
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing subscriber
+    tracing_subscriber::fmt::init();
+
     let api_key = env::var("GEMINI_API_KEY")?;
 
     // Create client with the default model (gemini-2.0-flash)
     let client = Gemini::new(api_key).expect("unable to create Gemini API client");
 
-    println!("Sending request to Gemini API...");
+    info!("sending request to gemini api");
 
     // Simple text completion with minimal content
     let response = client
@@ -17,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Response: {}", response.text());
+    info!(response = response.text(), "api test completed");
 
     Ok(())
 }

--- a/examples/text_thought_signature_example.rs
+++ b/examples/text_thought_signature_example.rs
@@ -4,9 +4,12 @@
 /// as seen in the Gemini 2.5 Flash API response format.
 use gemini_rust::{Content, GenerationResponse, Part};
 use serde_json::json;
+use tracing::info;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== Text with thoughtSignature Example ===\n");
+    tracing_subscriber::fmt::init();
+
+    info!("starting text with thoughtSignature example");
 
     // Simulate an API response similar to the one you provided
     let api_response = json!({
@@ -126,29 +129,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     thought_signature,
                 } = part
                 {
-                    println!(
-                        "\nPart {}: {} text{}",
-                        i + 1,
-                        if *thought == Some(true) {
+                    info!(
+                        part_number = i + 1,
+                        text_type = if *thought == Some(true) {
                             "Thought"
                         } else {
                             "Regular"
                         },
-                        if thought_signature.is_some() {
-                            " with signature"
-                        } else {
-                            ""
-                        }
+                        has_signature = thought_signature.is_some(),
+                        "part analysis"
                     );
 
                     if let Some(sig) = thought_signature {
-                        println!("  ↳ Preserve signature: {}...", &sig[..10.min(sig.len())]);
+                        info!(
+                            signature_preview = &sig[..10.min(sig.len())],
+                            "preserve signature"
+                        );
                     }
                 }
             }
         }
     }
 
-    println!("\n✅ Example completed successfully!");
+    info!("example completed successfully");
     Ok(())
 }

--- a/examples/text_thought_signature_example.rs
+++ b/examples/text_thought_signature_example.rs
@@ -2,13 +2,32 @@
 ///
 /// This example shows how to handle text responses that include thought signatures,
 /// as seen in the Gemini 2.5 Flash API response format.
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, GenerationResponse, Part};
 use serde_json::json;
+use std::process::ExitCode;
 use tracing::info;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     info!("starting text with thoughtSignature example");
 
     // Simulate an API response similar to the one you provided
@@ -51,8 +70,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the response
     let response: GenerationResponse = serde_json::from_value(api_response)?;
 
-    println!("📋 Parsed API Response:");
-    println!(
+    info!("📋 Parsed API Response:");
+    info!(
         "Model Version: {}",
         response
             .model_version
@@ -62,41 +81,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Display usage metadata
     if let Some(usage) = &response.usage_metadata {
-        println!("\n📊 Token Usage:");
+        info!("📊 Token Usage:");
         if let Some(prompt_token_count) = usage.prompt_token_count {
-            println!("  Prompt tokens: {}", prompt_token_count);
+            info!("  Prompt tokens: {}", prompt_token_count);
         }
-        println!(
+        info!(
             "  Response tokens: {}",
             usage.candidates_token_count.unwrap_or(0)
         );
         if let Some(total_token_count) = usage.total_token_count {
-            println!("  Total tokens: {}", total_token_count);
+            info!("  Total tokens: {}", total_token_count);
         }
         if let Some(thinking_tokens) = usage.thoughts_token_count {
-            println!("  Thinking tokens: {}", thinking_tokens);
+            info!("  Thinking tokens: {}", thinking_tokens);
         }
     }
 
     // Extract text parts with thought signatures using the new method
-    println!("\n💭 Text Parts with Thought Analysis:");
+    info!("💭 Text Parts with Thought Analysis:");
     let text_with_thoughts = response.text_with_thoughts();
 
     for (i, (text, is_thought, thought_signature)) in text_with_thoughts.iter().enumerate() {
-        println!("\n--- Part {} ---", i + 1);
-        println!("Is thought: {}", is_thought);
-        println!("Has thought signature: {}", thought_signature.is_some());
+        info!("--- Part {} ---", i + 1);
+        info!("Is thought: {}", is_thought);
+        info!("Has thought signature: {}", thought_signature.is_some());
 
         if let Some(signature) = thought_signature {
-            println!("Thought signature: {}", signature);
-            println!("Signature length: {} characters", signature.len());
+            info!("Thought signature: {}", signature);
+            info!("Signature length: {} characters", signature.len());
         }
 
-        println!("Text content: {}", text);
+        info!("Text content: {}", text);
     }
 
     // Demonstrate creating content with thought signatures
-    println!("\n🔧 Creating Content with Thought Signatures:");
+    info!("🔧 Creating Content with Thought Signatures:");
 
     let custom_content = Content::text_with_thought_signature(
         "This is a custom response with a thought signature",
@@ -108,16 +127,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "thinking_signature_def456",
     );
 
-    println!("Custom content JSON:");
-    println!("{}", serde_json::to_string_pretty(&custom_content)?);
+    info!("Custom content JSON:");
+    info!("{}", serde_json::to_string_pretty(&custom_content)?);
 
-    println!("\nCustom thought JSON:");
-    println!("{}", serde_json::to_string_pretty(&custom_thought)?);
+    info!("Custom thought JSON:");
+    info!("{}", serde_json::to_string_pretty(&custom_thought)?);
 
     // Show how this would be used in multi-turn conversation context
-    println!("\n🔄 Multi-turn Conversation Context:");
-    println!("In a multi-turn conversation, you would include these parts");
-    println!("with their thought signatures to maintain context:");
+    info!("🔄 Multi-turn Conversation Context:");
+    info!("In a multi-turn conversation, you would include these parts");
+    info!("with their thought signatures to maintain context:");
 
     // Extract the original parts for context preservation
     if let Some(candidate) = response.candidates.first() {

--- a/examples/thinking_advanced.rs
+++ b/examples/thinking_advanced.rs
@@ -1,14 +1,33 @@
+use display_error_chain::DisplayErrorChain;
 use futures::TryStreamExt;
 use gemini_rust::{
     FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails, ThinkingConfig,
 };
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -44,8 +63,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // Display general text content
-        print!("{}", chunk.text());
-        std::io::Write::flush(&mut std::io::stdout())?;
+        tracing::debug!(text = chunk.text(), "received text chunk");
     }
     info!("streaming response completed");
 

--- a/examples/thinking_basic.rs
+++ b/examples/thinking_basic.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, ThinkingConfig};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/thinking_basic.rs
+++ b/examples/thinking_basic.rs
@@ -1,20 +1,21 @@
 use gemini_rust::{Gemini, GenerationConfig, ThinkingConfig};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
     // Create client
     let client = Gemini::pro(api_key).expect("unable to create Gemini API client");
 
-    println!("=== Gemini 2.5 Thinking Basic Example ===\n");
+    info!("starting gemini 2.5 thinking basic example");
 
     // Example 1: Using default dynamic thinking
-    println!(
-        "--- Example 1: Dynamic thinking (model automatically determines thinking budget) ---"
-    );
+    info!("example 1: dynamic thinking (model automatically determines thinking budget)");
     let response1 = client
         .generate_content()
         .with_system_prompt("You are a helpful mathematics assistant.")
@@ -29,33 +30,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display thinking process
     let thoughts = response1.thoughts();
     if !thoughts.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
 
-    println!("Answer: {}\n", response1.text());
+    info!(answer = response1.text(), "answer");
 
     // Display token usage
     if let Some(usage) = &response1.usage_metadata {
-        println!("Token usage:");
+        info!("token usage");
         if let Some(prompt_tokens) = usage.prompt_token_count {
-            println!("  Prompt tokens: {}", prompt_tokens);
+            info!(prompt_tokens = prompt_tokens, "prompt tokens");
         }
         if let Some(response_tokens) = usage.candidates_token_count {
-            println!("  Response tokens: {}", response_tokens);
+            info!(response_tokens = response_tokens, "response tokens");
         }
         if let Some(thinking_tokens) = usage.thoughts_token_count {
-            println!("  Thinking tokens: {}", thinking_tokens);
+            info!(thinking_tokens = thinking_tokens, "thinking tokens");
         }
         if let Some(total_tokens) = usage.total_token_count {
-            println!("  Total tokens: {}\n", total_tokens);
+            info!(total_tokens = total_tokens, "total tokens");
         }
     }
 
     // Example 2: Set specific thinking budget
-    println!("--- Example 2: Set thinking budget (1024 tokens) ---");
+    info!("example 2: set thinking budget (1024 tokens)");
     let response2 = client
         .generate_content()
         .with_system_prompt("You are a helpful programming assistant.")
@@ -68,16 +69,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display thinking process
     let thoughts2 = response2.thoughts();
     if !thoughts2.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts2.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
 
-    println!("Answer: {}\n", response2.text());
+    info!(answer = response2.text(), "answer");
 
     // Example 3: Disable thinking feature
-    println!("--- Example 3: Disable thinking feature ---");
+    info!("example 3: disable thinking feature");
     let response3 = client
         .generate_content()
         .with_system_prompt("You are a helpful assistant.")
@@ -85,10 +86,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .execute()
         .await?;
 
-    println!("Answer: {}\n", response3.text());
+    info!(answer = response3.text(), "answer");
 
     // Example 4: Use GenerationConfig to set thinking
-    println!("--- Example 4: Use GenerationConfig to set thinking ---");
+    info!("example 4: use GenerationConfig to set thinking");
     let thinking_config = ThinkingConfig::new()
         .with_thinking_budget(2048)
         .with_thoughts_included(true);
@@ -113,13 +114,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display thinking process
     let thoughts4 = response4.thoughts();
     if !thoughts4.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts4.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
 
-    println!("Answer: {}\n", response4.text());
+    info!(answer = response4.text(), "answer");
 
     Ok(())
 }

--- a/examples/thinking_curl_equivalent.rs
+++ b/examples/thinking_curl_equivalent.rs
@@ -1,11 +1,30 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, ThinkingConfig};
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/thinking_curl_equivalent.rs
+++ b/examples/thinking_curl_equivalent.rs
@@ -1,8 +1,11 @@
 use gemini_rust::{Gemini, GenerationConfig, ThinkingConfig};
 use std::env;
+use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 
@@ -33,10 +36,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Gemini::with_model(api_key, "models/gemini-2.5-pro".to_string())
         .expect("unable to create Gemini API client");
 
-    println!("=== Thinking Curl Equivalent Example ===\n");
+    info!("starting thinking curl equivalent example");
 
     // Method 1: Using high-level API (simplest approach)
-    println!("--- Method 1: Using high-level API ---");
+    info!("method 1: using high-level API");
 
     let response1 = client
         .generate_content()
@@ -51,16 +54,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display thinking process
     let thoughts1 = response1.thoughts();
     if !thoughts1.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts1.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
 
-    println!("Answer: {}\n", response1.text());
+    info!(answer = response1.text(), "answer");
 
     // Method 2: Using GenerationConfig to fully match curl example structure
-    println!("--- Method 2: Fully matching curl example structure ---");
+    info!("method 2: fully matching curl example structure");
 
     let thinking_config = ThinkingConfig {
         thinking_budget: Some(1024),
@@ -84,45 +87,45 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Display thinking process
     let thoughts2 = response2.thoughts();
     if !thoughts2.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts2.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
 
-    println!("Answer: {}\n", response2.text());
+    info!(answer = response2.text(), "answer");
 
     // Show token usage
     if let Some(usage) = &response2.usage_metadata {
-        println!("Token usage:");
+        info!("token usage");
         if let Some(prompt_tokens) = usage.prompt_token_count {
-            println!("  Prompt tokens: {}", prompt_tokens);
+            info!(prompt_tokens = prompt_tokens, "prompt tokens");
         }
         if let Some(response_tokens) = usage.candidates_token_count {
-            println!("  Response tokens: {}", response_tokens);
+            info!(response_tokens = response_tokens, "response tokens");
         }
         if let Some(thinking_tokens) = usage.thoughts_token_count {
-            println!("  Thinking tokens: {}", thinking_tokens);
+            info!(thinking_tokens = thinking_tokens, "thinking tokens");
         }
         if let Some(total_tokens) = usage.total_token_count {
-            println!("  Total tokens: {}", total_tokens);
+            info!(total_tokens = total_tokens, "total tokens");
         }
     }
 
     // Method 3: Demonstrate different thinking budget settings
-    println!("\n--- Method 3: Different thinking budget comparison ---");
+    info!("method 3: different thinking budget comparison");
 
     // Thinking disabled
-    println!("Thinking disabled:");
+    info!("testing thinking disabled");
     let response_no_thinking = client
         .generate_content()
         .with_user_message("Explain the basic principles of quantum mechanics")
         .execute()
         .await?;
-    println!("Answer: {}\n", response_no_thinking.text());
+    info!(answer = response_no_thinking.text(), "answer");
 
     // Dynamic thinking
-    println!("Dynamic thinking:");
+    info!("testing dynamic thinking");
     let response_dynamic = client
         .generate_content()
         .with_user_message("Explain the basic principles of quantum mechanics")
@@ -133,15 +136,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let thoughts_dynamic = response_dynamic.thoughts();
     if !thoughts_dynamic.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts_dynamic.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
-    println!("Answer: {}\n", response_dynamic.text());
+    info!(answer = response_dynamic.text(), "answer");
 
     // High thinking budget
-    println!("High thinking budget (4096 tokens):");
+    info!("testing high thinking budget (4096 tokens)");
     let response_high_budget = client
         .generate_content()
         .with_user_message("Explain the basic principles of quantum mechanics")
@@ -152,12 +155,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let thoughts_high = response_high_budget.thoughts();
     if !thoughts_high.is_empty() {
-        println!("Thinking summary:");
+        info!("showing thinking summary");
         for (i, thought) in thoughts_high.iter().enumerate() {
-            println!("Thought {}: {}\n", i + 1, thought);
+            info!(thought_number = i + 1, thought = thought, "thought");
         }
     }
-    println!("Answer: {}", response_high_budget.text());
+    info!(answer = response_high_budget.text(), "answer");
 
     Ok(())
 }

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -1,3 +1,4 @@
+use display_error_chain::DisplayErrorChain;
 /// Comprehensive example demonstrating thoughtSignature support in Gemini 2.5 Pro
 ///
 /// This example shows:
@@ -19,12 +20,30 @@ use gemini_rust::{
 };
 use serde_json::json;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/examples/tools.rs
+++ b/examples/tools.rs
@@ -1,15 +1,34 @@
+use display_error_chain::DisplayErrorChain;
 use gemini_rust::{
     Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, Message,
     PropertyDetails, Role, Tool,
 };
 use serde_json::json;
 use std::env;
+use std::process::ExitCode;
 use tracing::info;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialize tracing subscriber
-    tracing_subscriber::fmt::init();
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
     // Get API key from environment variable
     let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
 

--- a/src/batch/builder.rs
+++ b/src/batch/builder.rs
@@ -1,6 +1,6 @@
 use snafu::ResultExt;
 use std::sync::Arc;
-use tracing::{debug, instrument, Span};
+use tracing::{instrument, Span};
 
 use super::handle::BatchHandle;
 use super::model::*;
@@ -73,17 +73,15 @@ impl BatchBuilder {
     /// Submits the batch request to the Gemini API and returns a `Batch` handle.
     ///
     /// This method consumes the builder and initiates the long-running batch operation.
-    #[instrument(skip_all, fields(display.name, requests.count))]
+    #[instrument(skip_all, fields(
+        batch.display_name = self.display_name,
+        batch.size = self.requests.len()
+    ))]
     pub async fn execute(self) -> Result<BatchHandle, Error> {
-        Span::current()
-            .record("display.name", &self.display_name)
-            .record("requests.count", self.requests.len());
-        debug!("executing batch request");
-
         let client = self.client.clone();
         let request = self.build();
         let response = client
-            .batch_generate_content_sync(request)
+            .batch_generate_content(request)
             .await
             .context(ClientSnafu)?;
         Ok(BatchHandle::new(response.name, client))
@@ -94,12 +92,11 @@ impl BatchBuilder {
     /// This method is ideal for large batch jobs that might exceed inline request limits.
     /// It consumes the builder, serializes the requests to the JSON Lines format,
     /// uploads the content as a file, and then starts the batch operation using that file.
-    #[instrument(skip_all, fields(display.name, requests.count, file.size))]
+    #[instrument(skip_all, fields(
+        batch.display_name = self.display_name,
+        batch.size = self.requests.len()
+    ))]
     pub async fn execute_as_file(self) -> Result<BatchHandle, Error> {
-        Span::current()
-            .record("display.name", &self.display_name)
-            .record("requests.count", self.requests.len());
-        debug!("executing batch request as file");
         let mut json_lines = String::new();
         for (index, item) in self.requests.into_iter().enumerate() {
             let item = BatchRequestFileItem {
@@ -135,7 +132,7 @@ impl BatchBuilder {
 
         let client = self.client.clone();
         let response = client
-            .batch_generate_content_sync(request)
+            .batch_generate_content(request)
             .await
             .context(ClientSnafu)?;
 

--- a/src/batch/model.rs
+++ b/src/batch/model.rs
@@ -261,6 +261,18 @@ pub enum InputConfig {
     FileName(String),
 }
 
+impl InputConfig {
+    /// Returns the batch size of the input configuration.
+    ///
+    /// Returns `None` if the input configuration is a file name.
+    pub fn batch_size(&self) -> Option<usize> {
+        match self {
+            InputConfig::Requests(container) => Some(container.requests.len()),
+            InputConfig::FileName(_) => None,
+        }
+    }
+}
+
 /// Container for requests
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/cache/builder.rs
+++ b/src/cache/builder.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, instrument, Span};
+use tracing::instrument;
 
 use snafu::ResultExt;
 
@@ -119,23 +119,15 @@ impl CacheBuilder {
     }
 
     /// Execute the cache creation request.
-    #[instrument(skip_all, fields(display.name, messages.count, tools.count, system_instruction.present))]
+    #[instrument(skip_all, fields(
+        display.name = self.display_name,
+        messages.count = self.contents.len(),
+        tools.count = self.tools.len(),
+        system_instruction.present = self.system_instruction.is_some(),
+    ))]
     pub async fn execute(self) -> Result<CachedContentHandle, Error> {
         let model = self.client.model.to_string();
         let expiration = self.expiration.ok_or(Error::MissingExpiration)?;
-
-        Span::current()
-            .record(
-                "display.name",
-                self.display_name.as_deref().unwrap_or("none"),
-            )
-            .record("messages.count", self.contents.len())
-            .record("tools.count", self.tools.len())
-            .record(
-                "system_instruction.present",
-                self.system_instruction.is_some(),
-            );
-        debug!("creating cached content");
 
         let cached_content = CreateCachedContentRequest {
             display_name: self.display_name,

--- a/src/cache/builder.rs
+++ b/src/cache/builder.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use std::time::Duration;
+use tracing::{debug, instrument, Span};
 
 use snafu::ResultExt;
 
@@ -118,9 +119,23 @@ impl CacheBuilder {
     }
 
     /// Execute the cache creation request.
+    #[instrument(skip_all, fields(display.name, messages.count, tools.count, system_instruction.present))]
     pub async fn execute(self) -> Result<CachedContentHandle, Error> {
         let model = self.client.model.to_string();
         let expiration = self.expiration.ok_or(Error::MissingExpiration)?;
+
+        Span::current()
+            .record(
+                "display.name",
+                self.display_name.as_deref().unwrap_or("none"),
+            )
+            .record("messages.count", self.contents.len())
+            .record("tools.count", self.tools.len())
+            .record(
+                "system_instruction.present",
+                self.system_instruction.is_some(),
+            );
+        debug!("creating cached content");
 
         let cached_content = CreateCachedContentRequest {
             display_name: self.display_name,

--- a/src/cache/handle.rs
+++ b/src/cache/handle.rs
@@ -45,7 +45,7 @@ impl CachedContentHandle {
     }
 
     /// Deletes the cached content resource from the server.
-    pub async fn delete(self) -> Result<DeleteCachedContentResponse, (Self, Error)> {
+    pub async fn delete(self) -> Result<(), (Self, Error)> {
         match self
             .client
             .delete_cached_content(&self.name)

--- a/src/cache/model.rs
+++ b/src/cache/model.rs
@@ -138,14 +138,6 @@ pub struct CreateCachedContentRequest {
     pub expiration: CacheExpirationRequest,
 }
 
-/// Response from deleting cached content.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct DeleteCachedContentResponse {
-    /// HTTP status and metadata
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub success: Option<bool>,
-}
-
 /// Summary of cached content (used in list operations, may omit large content fields).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/src/client.rs
+++ b/src/client.rs
@@ -204,8 +204,8 @@ impl GeminiClient {
     /// - Deserializing the response using a provided deserializer function
     ///
     /// # Type Parameters
-    /// * `B` - A function that takes a reference to the HTTP client and returns a RequestBuilder
-    /// * `D` - An async function that takes a Response and returns a Result<T, Error>
+    /// * `B` - A function that takes a `&Client` and returns a `RequestBuilder`
+    /// * `D` - An async function that takes ownership of a `Response` and returns a `Result<T, Error>`
     /// * `T` - The type of the deserialized response
     ///
     /// # Note

--- a/src/client.rs
+++ b/src/client.rs
@@ -16,16 +16,15 @@ use futures::{Stream, StreamExt, TryStreamExt};
 use mime::Mime;
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue, InvalidHeaderValue},
-    Client, ClientBuilder, Response,
+    Client, ClientBuilder, RequestBuilder, Response,
 };
-use serde::de::DeserializeOwned;
 use serde_json::json;
-use snafu::{ResultExt, Snafu};
+use snafu::{OptionExt, ResultExt, Snafu};
 use std::{
     fmt::{self, Formatter},
     sync::{Arc, LazyLock},
 };
-use tracing::{debug, instrument, Span};
+use tracing::{instrument, Level};
 use url::Url;
 
 use crate::batch::model::*;
@@ -80,7 +79,9 @@ impl fmt::Display for Model {
 #[snafu(visibility(pub))]
 pub enum Error {
     #[snafu(display("failed to parse API key"))]
-    InvalidApiKey { source: InvalidHeaderValue },
+    InvalidApiKey {
+        source: InvalidHeaderValue,
+    },
 
     #[snafu(display("failed to construct URL (probably incorrect model name): {suffix}"))]
     ConstructUrl {
@@ -88,8 +89,15 @@ pub enum Error {
         suffix: String,
     },
 
+    PerformRequestNew {
+        source: reqwest::Error,
+    },
+
     #[snafu(display("failed to perform request to '{url}'"))]
-    PerformRequest { source: reqwest::Error, url: Url },
+    PerformRequest {
+        source: reqwest::Error,
+        url: Url,
+    },
 
     #[snafu(display(
         "bad response from server; code {code}; description: {}",
@@ -102,26 +110,38 @@ pub enum Error {
         description: Option<String>,
     },
 
+    MissingResponseHeader {
+        header: String,
+    },
+
     #[snafu(display("failed to obtain stream SSE part"))]
     BadPart {
         source: EventStreamError<reqwest::Error>,
     },
 
     #[snafu(display("failed to deserialize JSON response"))]
-    Deserialize { source: serde_json::Error },
+    Deserialize {
+        source: serde_json::Error,
+    },
 
     #[snafu(display("failed to generate content"))]
-    DecodeResponse { source: reqwest::Error },
+    DecodeResponse {
+        source: reqwest::Error,
+    },
 
     #[snafu(display("failed to parse URL"))]
-    UrlParse { source: url::ParseError },
+    UrlParse {
+        source: url::ParseError,
+    },
 
     #[snafu(display("I/O error during file operations"))]
-    Io { source: std::io::Error },
+    Io {
+        source: std::io::Error,
+    },
 }
 
 /// Internal client for making requests to the Gemini API
-pub(crate) struct GeminiClient {
+pub struct GeminiClient {
     http_client: Client,
     pub model: Model,
     base_url: Url,
@@ -153,6 +173,7 @@ impl GeminiClient {
     }
 
     /// Check the response status code and return an error if it is not successful
+    #[tracing::instrument(skip_all, err)]
     async fn check_response(response: Response) -> Result<Response, Error> {
         let status = response.status();
         if !status.is_success() {
@@ -167,79 +188,146 @@ impl GeminiClient {
         }
     }
 
+    /// Performs an HTTP request to the Gemini API with standardized error handling.
+    ///
+    /// This method provides a generic way to make HTTP requests to the Gemini API with
+    /// consistent error handling, response checking, and deserialization. It handles:
+    /// - Building the HTTP request using a provided builder function
+    /// - Sending the request and handling network errors
+    /// - Checking the response status code for errors
+    /// - Deserializing the response using a provided deserializer function
+    ///
+    /// # Type Parameters
+    /// * `B` - A function that takes a reference to the HTTP client and returns a RequestBuilder
+    /// * `D` - An async function that takes a Response and returns a Result<T, Error>
+    /// * `T` - The type of the deserialized response
+    ///
+    /// # Note
+    /// The `AsyncFn` trait is a standard Rust feature (stabilized in v1.75) and does not
+    /// require any additional imports or feature flags.
+    ///
+    /// # Parameters
+    /// * `builder` - A function that constructs the HTTP request using the client
+    /// * `deserializer` - An async function that processes the response into the desired type
+    ///
+    /// # Examples
+    ///
+    /// Basic HTTP operations:
+    /// ```no_run
+    /// # use gemini_rust::client::*;
+    /// # use reqwest::Response;
+    /// # use url::Url;
+    /// # use serde_json::Value;
+    /// # use snafu::ResultExt;
+    /// # async fn examples(client: &GeminiClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// # let url: Url = "https://example.com".parse()?;
+    /// # let request = Value::Null;
+    ///
+    /// // POST request with JSON payload
+    /// let _response = client
+    ///     .perform_request(
+    ///         |c| c.post(url.clone()).json(&request),
+    ///         async |r| r.json().await.context(DecodeResponseSnafu),
+    ///     )
+    ///     .await?;
+    ///
+    /// // GET request with JSON response
+    /// let _response = client
+    ///     .perform_request(
+    ///         |c| c.get(url.clone()),
+    ///         async |r| r.json().await.context(DecodeResponseSnafu),
+    ///     )
+    ///     .await?;
+    ///
+    /// // DELETE request with no response body
+    /// let _response = client
+    ///     .perform_request(|c| c.delete(url), async |_r| Ok(()))
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Request returning a stream:
+    /// ```no_run
+    /// # use gemini_rust::client::*;
+    /// # use reqwest::Response;
+    /// # use url::Url;
+    /// # use serde_json::Value;
+    /// # async fn example(client: &GeminiClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// # let url: Url = "https://example.com".parse()?;
+    /// # let request = Value::Null;
+    /// let _stream = client
+    ///     .perform_request(
+    ///         |c| c.post(url).json(&request),
+    ///         async |r| Ok(r.bytes_stream()),
+    ///     )
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[tracing::instrument(skip_all)]
+    #[doc(hidden)]
+    pub async fn perform_request<
+        B: FnOnce(&Client) -> RequestBuilder,
+        D: AsyncFn(Response) -> Result<T, Error>,
+        T,
+    >(
+        &self,
+        builder: B,
+        deserializer: D,
+    ) -> Result<T, Error> {
+        let request = builder(&self.http_client);
+        tracing::debug!("request built successfully");
+        let response = request.send().await.context(PerformRequestNewSnafu)?;
+        tracing::debug!("response received successfully");
+        let response = Self::check_response(response).await?;
+        tracing::debug!("response ok");
+        deserializer(response).await
+    }
+
     /// Generate content
-    #[instrument(skip_all, fields(model, url, status.code, parts.total))]
+    #[instrument(skip_all, fields(
+        model,
+        messages.parts.count = request.contents.len(),
+        tools.present = request.tools.is_some(),
+        system.instruction.present = request.system_instruction.is_some(),
+        cached.content.present = request.cached_content.is_some(),
+    ))]
     pub(crate) async fn generate_content_raw(
         &self,
         request: GenerateContentRequest,
     ) -> Result<GenerationResponse, Error> {
-        Span::current().record("model", self.model.as_str());
-
-        let parts_total = request
-            .contents
-            .iter()
-            .map(|c| c.parts.as_ref().map(|p| p.len()).unwrap_or(0))
-            .sum::<usize>();
-        Span::current().record("parts.total", parts_total);
-
         let url = self.build_url("generateContent")?;
-        Span::current().record("url", url.as_str());
-        debug!("generating content");
-
-        let response = self
-            .http_client
-            .post(url.clone())
-            .json(&request)
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        let status_code = response.status().as_u16();
-        Span::current().record("status.code", status_code);
-        debug!("generation completed");
-
-        Self::check_response(response)
-            .await?
-            .json()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.post(url.clone()).json(&request),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Generate content with streaming
-    #[instrument(skip_all, fields(model, url, status.code, parts.total))]
+    #[instrument(skip_all, fields(
+        model,
+        messages.parts.count = request.contents.len(),
+        tools.present = request.tools.is_some(),
+        system.instruction.present = request.system_instruction.is_some(),
+        cached.content.present = request.cached_content.is_some(),
+    ))]
     pub(crate) async fn generate_content_stream(
         &self,
         request: GenerateContentRequest,
     ) -> Result<impl TryStreamExt<Ok = GenerationResponse, Error = Error> + Send, Error> {
-        Span::current().record("model", self.model.as_str());
-
-        let parts_total = request
-            .contents
-            .iter()
-            .map(|c| c.parts.as_ref().map(|p| p.len()).unwrap_or(0))
-            .sum::<usize>();
-        Span::current().record("parts.total", parts_total);
-
         let mut url = self.build_url("streamGenerateContent")?;
         url.query_pairs_mut().append_pair("alt", "sse");
-        Span::current().record("url", url.as_str());
-        debug!("starting streaming generation");
 
-        let response = self
-            .http_client
-            .post(url.clone())
-            .json(&request)
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
+        let stream = self
+            .perform_request(
+                |c| c.post(url).json(&request),
+                async |r| Ok(r.bytes_stream()),
+            )
+            .await?;
 
-        let status_code = response.status().as_u16();
-        Span::current().record("status.code", status_code);
-        debug!("streaming established");
-
-        Ok(Self::check_response(response)
-            .await?
-            .bytes_stream()
+        Ok(stream
             .eventsource()
             .map(|event| event.context(BadPartSnafu))
             .map_ok(|event| {
@@ -249,65 +337,76 @@ impl GeminiClient {
     }
 
     /// Embed content
-    #[instrument(skip_all, fields(model))]
+    #[instrument(skip_all, fields(
+        model,
+        task.type = request.task_type.as_ref().map(|t| format!("{:?}", t)),
+        task.title = request.title,
+        task.output.dimensionality = request.output_dimensionality,
+    ))]
     pub(crate) async fn embed_content(
         &self,
         request: EmbedContentRequest,
     ) -> Result<ContentEmbeddingResponse, Error> {
-        Span::current().record("model", self.model.as_str());
-        debug!("embedding content");
-        self.post_json(request, "embedContent").await
+        let url = self.build_url("embedContent")?;
+        self.perform_request(
+            |c| c.post(url).json(&request),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Batch Embed content
-    #[instrument(skip_all, fields(model, batch.size))]
+    #[instrument(skip_all, fields(batch.size = request.requests.len()))]
     pub(crate) async fn embed_content_batch(
         &self,
         request: BatchEmbedContentsRequest,
     ) -> Result<BatchContentEmbeddingResponse, Error> {
-        Span::current()
-            .record("model", self.model.as_str())
-            .record("batch.size", request.requests.len());
-        debug!("batch embedding content");
-        self.post_json(request, "batchEmbedContents").await
+        let url = self.build_url("batchEmbedContents")?;
+        self.perform_request(
+            |c| c.post(url).json(&request),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Synchronous Batch Generate content
-    #[instrument(skip_all, fields(model, batch.display_name))]
-    pub(crate) async fn batch_generate_content_sync(
+    #[instrument(skip_all, fields(
+        batch.display_name = request.batch.display_name,
+        batch.size = request.batch.input_config.batch_size(),
+    ))]
+    pub(crate) async fn batch_generate_content(
         &self,
         request: BatchGenerateContentRequest,
     ) -> Result<BatchGenerateContentResponse, Error> {
-        Span::current()
-            .record("model", self.model.as_str())
-            .record("batch.display_name", &request.batch.display_name);
-        debug!("synchronous batch generate content");
-        let value = self.post_json(request, "batchGenerateContent").await?;
-        serde_json::from_value(value).context(DeserializeSnafu)
+        let url = self.build_url("batchGenerateContent")?;
+        self.perform_request(
+            |c| c.post(url).json(&request),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Get a batch operation
+    #[instrument(skip_all, fields(
+        operation.name = name,
+    ))]
     pub(crate) async fn get_batch_operation<T: serde::de::DeserializeOwned>(
         &self,
         name: &str,
     ) -> Result<T, Error> {
         let url = self.build_batch_url(name, None)?;
-
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.get(url),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// List batch operations
+    #[instrument(skip_all, fields(
+        page.size = page_size,
+        page.token.present = page_token.is_some(),
+    ))]
     pub(crate) async fn list_batch_operations(
         &self,
         page_size: Option<u32>,
@@ -323,21 +422,18 @@ impl GeminiClient {
             url.query_pairs_mut().append_pair("pageToken", &token);
         }
 
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.get(url),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// List files
+    #[instrument(skip_all, fields(
+        page.size = page_size,
+        page.token.present = page_token.is_some(),
+    ))]
     pub(crate) async fn list_files(
         &self,
         page_size: Option<u32>,
@@ -353,106 +449,96 @@ impl GeminiClient {
             url.query_pairs_mut().append_pair("pageToken", &token);
         }
 
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.get(url),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Cancel a batch operation
+    #[instrument(skip_all, fields(
+        operation.name = name,
+    ))]
     pub(crate) async fn cancel_batch_operation(&self, name: &str) -> Result<(), Error> {
         let url = self.build_batch_url(name, Some("cancel"))?;
-        let response = self
-            .http_client
-            .post(url.clone())
-            .json(&json!({}))
-            .send()
+        self.perform_request(|c| c.post(url).json(&json!({})), async |_r| Ok(()))
             .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response).await?;
-        Ok(())
     }
 
     /// Delete a batch operation
+    #[instrument(skip_all, fields(
+        operation.name = name,
+    ))]
     pub(crate) async fn delete_batch_operation(&self, name: &str) -> Result<(), Error> {
         let url = self.build_batch_url(name, None)?;
-        let response = self
-            .http_client
-            .delete(url.clone())
-            .send()
+        self.perform_request(|c| c.delete(url), async |_r| Ok(()))
             .await
-            .context(PerformRequestSnafu { url })?;
+    }
 
-        Self::check_response(response).await?;
-        Ok(())
+    async fn create_upload(
+        &self,
+        bytes: usize,
+        display_name: Option<String>,
+        mime_type: Mime,
+    ) -> Result<Url, Error> {
+        let url = self
+            .base_url
+            .join("/upload/v1beta/files")
+            .context(ConstructUrlSnafu {
+                suffix: "/upload/v1beta/files".to_string(),
+            })?;
+
+        self.perform_request(
+            |c| {
+                c.post(url)
+                    .header("X-Goog-Upload-Protocol", "resumable")
+                    .header("X-Goog-Upload-Command", "start")
+                    .header("X-Goog-Upload-Content-Length", bytes.to_string())
+                    .header("X-Goog-Upload-Header-Content-Type", mime_type.to_string())
+                    .json(&json!({"file": {"displayName": display_name}}))
+            },
+            async |r| {
+                r.headers()
+                    .get("X-Goog-Upload-URL")
+                    .context(MissingResponseHeaderSnafu {
+                        header: "X-Goog-Upload-URL",
+                    })
+                    .and_then(|upload_url| {
+                        upload_url
+                            .to_str()
+                            .map(str::to_string)
+                            .map_err(|_| Error::BadResponse {
+                                code: 500,
+                                description: Some("Missing upload URL in response".to_string()),
+                            })
+                    })
+                    .and_then(|url| Url::parse(&url).context(UrlParseSnafu))
+            },
+        )
+        .await
     }
 
     /// Upload a file using the resumable upload protocol.
-    #[instrument(skip_all, fields(file.size, mime.type, file.display_name))]
+    #[instrument(skip_all, fields(
+        file.size = file_bytes.len(),
+        mime.type = mime_type.to_string(),
+        file.display_name = display_name.as_deref(),
+    ))]
     pub(crate) async fn upload_file(
         &self,
         display_name: Option<String>,
         file_bytes: Vec<u8>,
         mime_type: Mime,
     ) -> Result<File, Error> {
-        Span::current()
-            .record("file.size", file_bytes.len())
-            .record("mime.type", mime_type.to_string())
-            .record(
-                "file.display_name",
-                display_name.as_deref().unwrap_or("none"),
-            );
-        debug!("starting file upload");
-        // Step 1: Initiate resumable upload
-        // The upload URL is different from the metadata URL, so we construct it relative to the base URL's root.
-        let initiate_url =
-            self.base_url
-                .join("/upload/v1beta/files")
-                .context(ConstructUrlSnafu {
-                    suffix: "/upload/v1beta/files".to_string(),
-                })?;
-
-        let response = self
-            .http_client
-            .post(initiate_url.clone())
-            .header("X-Goog-Upload-Protocol", "resumable")
-            .header("X-Goog-Upload-Command", "start")
-            .header(
-                "X-Goog-Upload-Header-Content-Length",
-                file_bytes.len().to_string(),
-            )
-            .header("X-Goog-Upload-Header-Content-Type", mime_type.to_string())
-            .json(&json!({"file": {"displayName": display_name}}))
-            .send()
-            .await
-            .context(PerformRequestSnafu {
-                url: initiate_url.clone(),
-            })?;
-
-        let checked_response = Self::check_response(response).await?;
-
-        let upload_url = checked_response
-            .headers()
-            .get("X-Goog-Upload-URL")
-            .and_then(|h| h.to_str().ok())
-            .ok_or_else(|| Error::BadResponse {
-                code: 500,
-                description: Some("Missing upload URL in response".to_string()),
-            })?;
+        let upload_url = self
+            .create_upload(file_bytes.len(), display_name, mime_type)
+            .await?;
 
         // Step 2: Upload file content
         let upload_response = self
             .http_client
-            .post(upload_url)
+            .post(upload_url.clone())
             .header("X-Goog-Upload-Command", "upload, finalize")
             .header("X-Goog-Upload-Offset", "0")
             .body(file_bytes)
@@ -460,7 +546,7 @@ impl GeminiClient {
             .await
             .map_err(|e| Error::PerformRequest {
                 source: e,
-                url: Url::parse(upload_url).unwrap_or_else(|_| initiate_url.clone()),
+                url: upload_url,
             })?;
 
         let final_response = Self::check_response(upload_response).await?;
@@ -476,36 +562,31 @@ impl GeminiClient {
     }
 
     /// Get a file resource
+    #[instrument(skip_all, fields(
+        file.name = name,
+    ))]
     pub(crate) async fn get_file(&self, name: &str) -> Result<File, Error> {
         let url = self.build_files_url(Some(name))?;
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.get(url),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Delete a file resource
+    #[instrument(skip_all, fields(
+        file.name = name,
+    ))]
     pub(crate) async fn delete_file(&self, name: &str) -> Result<(), Error> {
         let url = self.build_files_url(Some(name))?;
-        let response = self
-            .http_client
-            .delete(url.clone())
-            .send()
+        self.perform_request(|c| c.delete(url), async |_r| Ok(()))
             .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response).await?;
-        Ok(())
     }
 
+    #[instrument(skip_all, fields(
+        file.name = name,
+    ))]
     pub(crate) async fn download_file(&self, name: &str) -> Result<Vec<u8>, Error> {
         let mut url = self
             .base_url
@@ -515,51 +596,16 @@ impl GeminiClient {
             })?;
         url.query_pairs_mut().append_pair("alt", "media");
 
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url: url.clone() })?;
-
-        Self::check_response(response)
-            .await?
-            .bytes()
-            .await
-            .context(PerformRequestSnafu { url })
-            .map(|b| b.to_vec())
-    }
-
-    /// Post JSON to an endpoint
-    #[instrument(skip_all, fields(endpoint, url, status.code))]
-    async fn post_json<I: serde::Serialize, O: DeserializeOwned>(
-        &self,
-        request: I,
-        endpoint: &str,
-    ) -> Result<O, Error> {
-        Span::current().record("endpoint", endpoint);
-
-        let url = self.build_url(endpoint)?;
-        Span::current().record("url", url.as_str());
-        debug!("sending post request");
-
-        let response = self
-            .http_client
-            .post(url.clone())
-            .json(&request)
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        let status_code = response.status().as_u16();
-        Span::current().record("status.code", status_code);
-        debug!("received response");
-
-        Self::check_response(response)
-            .await?
-            .json::<O>()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.get(url),
+            async |r| {
+                r.bytes()
+                    .await
+                    .context(DecodeResponseSnafu)
+                    .map(|bytes| bytes.to_vec())
+            },
+        )
+        .await
     }
 
     /// Create cached content
@@ -568,36 +614,21 @@ impl GeminiClient {
         cached_content: CreateCachedContentRequest,
     ) -> Result<CachedContent, Error> {
         let url = self.build_cache_url(None)?;
-        let response = self
-            .http_client
-            .post(url.clone())
-            .json(&cached_content)
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json::<CachedContent>()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.post(url).json(&cached_content),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Get cached content
     pub(crate) async fn get_cached_content(&self, name: &str) -> Result<CachedContent, Error> {
         let url = self.build_cache_url(Some(name))?;
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json::<CachedContent>()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.get(url.clone()),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Update cached content (typically to update TTL)
@@ -616,46 +647,18 @@ impl GeminiClient {
             }
         };
 
-        let response = self
-            .http_client
-            .patch(url.clone())
-            .json(&update_payload)
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
-
-        Self::check_response(response)
-            .await?
-            .json::<CachedContent>()
-            .await
-            .context(DecodeResponseSnafu)
+        self.perform_request(
+            |c| c.patch(url.clone()).json(&update_payload),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
     }
 
     /// Delete cached content
-    pub(crate) async fn delete_cached_content(
-        &self,
-        name: &str,
-    ) -> Result<DeleteCachedContentResponse, Error> {
+    pub(crate) async fn delete_cached_content(&self, name: &str) -> Result<(), Error> {
         let url = self.build_cache_url(Some(name))?;
-        let response = self
-            .http_client
-            .delete(url.clone())
-            .send()
+        self.perform_request(|c| c.delete(url.clone()), async |_r| Ok(()))
             .await
-            .context(PerformRequestSnafu { url })?;
-
-        // For DELETE operations, we might get an empty response, so handle that case
-        if response.status().is_success() {
-            Ok(DeleteCachedContentResponse {
-                success: Some(true),
-            })
-        } else {
-            Self::check_response(response)
-                .await?
-                .json::<DeleteCachedContentResponse>()
-                .await
-                .context(DecodeResponseSnafu)
-        }
     }
 
     /// List cached contents
@@ -674,25 +677,26 @@ impl GeminiClient {
             url.query_pairs_mut().append_pair("pageToken", &token);
         }
 
-        let response = self
-            .http_client
-            .get(url.clone())
-            .send()
-            .await
-            .context(PerformRequestSnafu { url })?;
+        self.perform_request(
+            |c| c.get(url.clone()),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
+    }
 
-        Self::check_response(response)
-            .await?
-            .json::<ListCachedContentsResponse>()
-            .await
-            .context(DecodeResponseSnafu)
+    /// Build a URL with the given suffix
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG))]
+    fn build_url_with_suffix(&self, suffix: &str) -> Result<Url, Error> {
+        self.base_url.join(suffix).context(ConstructUrlSnafu {
+            suffix: suffix.to_string(),
+        })
     }
 
     /// Build a URL for the API
+    #[tracing::instrument(skip(self), ret(level = Level::DEBUG))]
     fn build_url(&self, endpoint: &str) -> Result<Url, Error> {
-        let url = self.base_url.clone();
         let suffix = format!("{}:{endpoint}", self.model);
-        url.join(&suffix).context(ConstructUrlSnafu { suffix })
+        self.build_url_with_suffix(&suffix)
     }
 
     /// Build a URL for a batch operation
@@ -700,9 +704,7 @@ impl GeminiClient {
         let suffix = action
             .map(|a| format!("{name}:{a}"))
             .unwrap_or_else(|| name.to_string());
-
-        let url = self.base_url.clone();
-        url.join(&suffix).context(ConstructUrlSnafu { suffix })
+        self.build_url_with_suffix(&suffix)
     }
 
     /// Build a URL for file operations
@@ -710,10 +712,7 @@ impl GeminiClient {
         let suffix = name
             .map(|n| format!("files/{}", n.strip_prefix("files/").unwrap_or(n)))
             .unwrap_or_else(|| "files".to_string());
-
-        self.base_url
-            .join(&suffix)
-            .context(ConstructUrlSnafu { suffix })
+        self.build_url_with_suffix(&suffix)
     }
 
     /// Build a URL for cache operations
@@ -727,10 +726,7 @@ impl GeminiClient {
                 }
             })
             .unwrap_or_else(|| "cachedContents".to_string());
-
-        self.base_url
-            .join(&suffix)
-            .context(ConstructUrlSnafu { suffix })
+        self.build_url_with_suffix(&suffix)
     }
 }
 

--- a/src/embedding/model.rs
+++ b/src/embedding/model.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use strum_macros::AsRefStr;
 
 use crate::Content;
 
@@ -51,8 +52,9 @@ pub struct BatchEmbedContentsRequest {
 }
 
 /// Task types for embedding optimization
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsRefStr)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum TaskType {
     /// Used to generate embeddings that are optimized to assess text similarity
     SemanticSimilarity,

--- a/src/files/builder.rs
+++ b/src/files/builder.rs
@@ -1,7 +1,7 @@
 use mime::Mime;
 use snafu::ResultExt;
 use std::sync::Arc;
-use tracing::{debug, instrument, Span};
+use tracing::instrument;
 
 use super::*;
 use crate::client::GeminiClient;
@@ -37,18 +37,13 @@ impl FileBuilder {
     }
 
     /// Upload the file.
-    #[instrument(skip_all, fields(file.size, mime.type, display.name))]
+    #[instrument(skip_all, fields(
+        file.size = self.file_bytes.len(),
+        mime.type = self.mime_type.as_ref().map(|m| m.to_string()),
+        file.display_name = self.display_name,
+    ))]
     pub async fn upload(self) -> Result<super::handle::FileHandle, super::Error> {
         let mime_type = self.mime_type.unwrap_or(mime::APPLICATION_OCTET_STREAM);
-
-        Span::current()
-            .record("file.size", self.file_bytes.len())
-            .record("mime.type", mime_type.to_string())
-            .record(
-                "display.name",
-                self.display_name.as_deref().unwrap_or("none"),
-            );
-        debug!("uploading file");
 
         let file = self
             .client

--- a/src/generation/builder.rs
+++ b/src/generation/builder.rs
@@ -1,6 +1,6 @@
 use futures::TryStream;
 use std::sync::Arc;
-use tracing::{debug, instrument, Span};
+use tracing::instrument;
 
 use crate::{
     cache::CachedContentHandle,
@@ -350,37 +350,29 @@ impl ContentBuilder {
     }
 
     /// Execute the request
-    #[instrument(skip_all, fields(messages.count, tools.present, system_instruction.present))]
+    #[instrument(skip_all, fields(
+        messages.parts.count = self.contents.len(),
+        tools.present = self.tools.is_some(),
+        system.instruction.present = self.system_instruction.is_some(),
+        cached.content.present = self.cached_content.is_some(),
+    ))]
     pub async fn execute(self) -> Result<GenerationResponse, ClientError> {
-        Span::current()
-            .record("messages.count", self.contents.len())
-            .record("tools.present", self.tools.is_some())
-            .record(
-                "system_instruction.present",
-                self.system_instruction.is_some(),
-            );
-        debug!("executing generation request");
-
         let client = self.client.clone();
         let request = self.build();
         client.generate_content_raw(request).await
     }
 
     /// Execute the request with streaming
-    #[instrument(skip_all, fields(messages.count, tools.present, system_instruction.present))]
+    #[instrument(skip_all, fields(
+        messages.parts.count = self.contents.len(),
+        tools.present = self.tools.is_some(),
+        system.instruction.present = self.system_instruction.is_some(),
+        cached.content.present = self.cached_content.is_some(),
+    ))]
     pub async fn execute_stream(
         self,
     ) -> Result<impl TryStream<Ok = GenerationResponse, Error = ClientError> + Send, ClientError>
     {
-        Span::current()
-            .record("messages.count", self.contents.len())
-            .record("tools.present", self.tools.is_some())
-            .record(
-                "system_instruction.present",
-                self.system_instruction.is_some(),
-            );
-        debug!("executing streaming generation request");
-
         let request = GenerateContentRequest {
             contents: self.contents,
             generation_config: self.generation_config,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! For more specialized types, import them directly from the crate root or their
 //! respective modules.
 
-mod client;
+pub mod client;
 mod models;
 
 /// Convenient re-exports of commonly used types


### PR DESCRIPTION
Fixes #33 

## Plan

- [x] Implement basic tracing for IO-bound methods.
- [x] Transit examples from print-based logging to `tracing`-based.
- [x] Documentation.
  - [x] Add basic `AGENTS.md` that helps agents to not mess with logging during refactoring.
  - [x] Add information about tracing into `README.md`.

## NB

This is not optimized implementation. I want to create useful examples first and optimize later.