### PR TITLE
`GenerationResponse` deserialization bug fix.

### DIFF
--- a/src/batch/model.rs
+++ b/src/batch/model.rs
@@ -198,6 +198,7 @@ pub struct BatchStats {
 
 /// Represents a long-running operation from the Gemini API.
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BatchOperation {
     /// The resource name of the operation
     pub name: String,

--- a/src/generation/model.rs
+++ b/src/generation/model.rs
@@ -130,6 +130,7 @@ pub struct PromptTokenDetails {
 #[serde(rename_all = "camelCase")]
 pub struct GenerationResponse {
     /// The candidates generated
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub candidates: Vec<Candidate>,
     /// The prompt feedback
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -168,6 +169,7 @@ pub enum BlockReason {
 #[serde(rename_all = "camelCase")]
 pub struct PromptFeedback {
     /// The safety ratings for the prompt
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub safety_ratings: Vec<SafetyRating>,
     /// The block reason if the prompt was blocked
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Problem

In the JSON structure returned by the server, there may be no `candidates` field if the request was blocked (the `prompt_feedback` field contains information about the reasons for blocking).

## Solution

  I added the `#[serde(default)]` modifier for it, so that in case of its absence, an empty vector is generated.