### PR TITLE
Function declaration array of objects parameter

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,6 +1,5 @@
 use gemini_rust::{
-    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, Part,
-    PropertyDetails,
+    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameter, Gemini, Part,
 };
 use std::env;
 
@@ -15,15 +14,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let get_weather = FunctionDeclaration::new(
         "get_weather",
         "Get the current weather for a location",
-        FunctionParameters::object()
+        FunctionParameter::object_builder()
             .with_property(
                 "location",
-                PropertyDetails::string("The city and state, e.g., San Francisco, CA"),
+                FunctionParameter::string("The city and state, e.g., San Francisco, CA"),
                 true,
             )
             .with_property(
                 "unit",
-                PropertyDetails::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
+                FunctionParameter::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
                 false,
             ),
     );

--- a/examples/google_search_with_functions.rs
+++ b/examples/google_search_with_functions.rs
@@ -1,6 +1,6 @@
 use gemini_rust::{
-    Content, FunctionCall, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini,
-    Message, PropertyDetails, Role, Tool,
+    Content, FunctionCall, FunctionCallingMode, FunctionDeclaration, FunctionParameter, Gemini,
+    Message, Role, Tool,
 };
 use serde_json::json;
 use std::env;
@@ -19,28 +19,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let schedule_meeting = FunctionDeclaration::new(
         "schedule_meeting",
         "Schedules a meeting with specified attendees at a given time and date.",
-        FunctionParameters::object()
+        FunctionParameter::object_builder()
             .with_property(
                 "attendees",
-                PropertyDetails::array(
+                FunctionParameter::array(
                     "List of people attending the meeting.",
-                    PropertyDetails::string("Attendee name"),
+                    FunctionParameter::string("Attendee name"),
                 ),
                 true,
             )
             .with_property(
                 "date",
-                PropertyDetails::string("Date of the meeting (e.g., '2024-07-29')"),
+                FunctionParameter::string("Date of the meeting (e.g., '2024-07-29')"),
                 true,
             )
             .with_property(
                 "time",
-                PropertyDetails::string("Time of the meeting (e.g., '15:00')"),
+                FunctionParameter::string("Time of the meeting (e.g., '15:00')"),
                 true,
             )
             .with_property(
                 "topic",
-                PropertyDetails::string("The subject or topic of the meeting."),
+                FunctionParameter::string("The subject or topic of the meeting."),
                 true,
             ),
     );

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use gemini_rust::{
-    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini,
-    GenerationConfig, Message, PropertyDetails, Role,
+    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameter, Gemini, GenerationConfig,
+    Message, Role,
 };
 use std::env;
 
@@ -34,15 +34,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let get_weather = FunctionDeclaration::new(
         "get_weather",
         "Get the current weather for a location",
-        FunctionParameters::object()
+        FunctionParameter::object_builder()
             .with_property(
                 "location",
-                PropertyDetails::string("The city and state, e.g., San Francisco, CA"),
+                FunctionParameter::string("The city and state, e.g., San Francisco, CA"),
                 true,
             )
             .with_property(
                 "unit",
-                PropertyDetails::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
+                FunctionParameter::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
                 false,
             ),
     );

--- a/examples/simple_thought_signature.rs
+++ b/examples/simple_thought_signature.rs
@@ -1,6 +1,5 @@
 use gemini_rust::{
-    FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails,
-    ThinkingConfig, Tool,
+    FunctionCallingMode, FunctionDeclaration, FunctionParameter, Gemini, ThinkingConfig, Tool,
 };
 use std::env;
 
@@ -13,9 +12,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let weather_function = FunctionDeclaration::new(
         "get_weather",
         "Get current weather for a location",
-        FunctionParameters::object().with_property(
+        FunctionParameter::object_builder().with_property(
             "location",
-            PropertyDetails::string("City name"),
+            FunctionParameter::string("City name"),
             true,
         ),
     );

--- a/examples/thinking_advanced.rs
+++ b/examples/thinking_advanced.rs
@@ -1,7 +1,5 @@
 use futures::TryStreamExt;
-use gemini_rust::{
-    FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails, ThinkingConfig,
-};
+use gemini_rust::{FunctionDeclaration, FunctionParameter, Gemini, ThinkingConfig};
 use std::env;
 
 #[tokio::main]
@@ -53,17 +51,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let calculator = FunctionDeclaration::new(
         "calculate",
         "Perform basic mathematical calculations",
-        FunctionParameters::object()
+        FunctionParameter::object_builder()
             .with_property(
                 "expression",
-                PropertyDetails::string(
+                FunctionParameter::string(
                     "The mathematical expression to calculate, e.g., '2 + 3 * 4'",
                 ),
                 true,
             )
             .with_property(
                 "operation_type",
-                PropertyDetails::enum_type("Type of calculation", ["arithmetic", "advanced"]),
+                FunctionParameter::enum_type("Type of calculation", ["arithmetic", "advanced"]),
                 false,
             ),
     );

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -14,8 +14,8 @@
 /// Thought signatures are encrypted representations of the model's internal
 /// thought process that help maintain context across conversation turns.
 use gemini_rust::{
-    FunctionCallingMode, FunctionDeclaration, FunctionParameters, FunctionResponse, Gemini,
-    PropertyDetails, ThinkingConfig, Tool,
+    FunctionCallingMode, FunctionDeclaration, FunctionParameter, FunctionResponse, Gemini,
+    ThinkingConfig, Tool,
 };
 use serde_json::json;
 use std::env;
@@ -34,9 +34,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let weather_function = FunctionDeclaration::new(
         "get_current_weather",
         "Get current weather information for a specified location",
-        FunctionParameters::object().with_property(
+        FunctionParameter::object_builder().with_property(
             "location",
-            PropertyDetails::string("City and region, e.g., Kaohsiung Zuoying District"),
+            FunctionParameter::string("City and region, e.g., Kaohsiung Zuoying District"),
             true,
         ),
     );
@@ -187,9 +187,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let weather_tool_followup = Tool::new(FunctionDeclaration::new(
                 "get_current_weather",
                 "Get current weather information for a specified location",
-                FunctionParameters::object().with_property(
+                FunctionParameter::object_builder().with_property(
                     "location",
-                    PropertyDetails::string("City and region, e.g., Kaohsiung Zuoying District"),
+                    FunctionParameter::string("City and region, e.g., Kaohsiung Zuoying District"),
                     true,
                 ),
             ));

--- a/examples/tools.rs
+++ b/examples/tools.rs
@@ -1,6 +1,6 @@
 use gemini_rust::{
-    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, Message,
-    PropertyDetails, Role, Tool,
+    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameter, Gemini, Message, Role,
+    Tool,
 };
 use serde_json::json;
 use std::env;
@@ -19,15 +19,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let get_weather = FunctionDeclaration::new(
         "get_weather",
         "Get the current weather for a location",
-        FunctionParameters::object()
+        FunctionParameter::object_builder()
             .with_property(
                 "location",
-                PropertyDetails::string("The city and state, e.g., San Francisco, CA"),
+                FunctionParameter::string("The city and state, e.g., San Francisco, CA"),
                 true,
             )
             .with_property(
                 "unit",
-                PropertyDetails::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
+                FunctionParameter::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
                 false,
             ),
     );
@@ -36,17 +36,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let calculate = FunctionDeclaration::new(
         "calculate",
         "Perform a calculation",
-        FunctionParameters::object()
+        FunctionParameter::object_builder()
             .with_property(
                 "operation",
-                PropertyDetails::enum_type(
+                FunctionParameter::enum_type(
                     "The mathematical operation to perform",
                     ["add", "subtract", "multiply", "divide"],
                 ),
                 true,
             )
-            .with_property("a", PropertyDetails::number("The first number"), true)
-            .with_property("b", PropertyDetails::number("The second number"), true),
+            .with_property("a", FunctionParameter::number("The first number"), true)
+            .with_property("b", FunctionParameter::number("The second number"), true),
     );
 
     // Create a tool with multiple functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ pub use safety::model::{
 
 pub use tools::model::{
     FunctionCall, FunctionCallingConfig, FunctionCallingMode, FunctionDeclaration,
-    FunctionParameters, FunctionResponse, PropertyDetails, Tool, ToolConfig,
+    FunctionParameter, FunctionParameterObjectBuilder, FunctionResponse, Tool, ToolConfig,
 };
 
 // ========== Batch Processing ==========


### PR DESCRIPTION
The Gemini API allows nested objects in function declaration parameters. e.g. an array of objects
```json
{
  "name": "addToList",
  "description": "Add widgets to a list.",
  "parameters": {
    "type": "object",
    "properties": {
      "widgets": {
        "type": "array",
        "description": "The widgets to add.",
        "items": {
          "type": "object",
          "properties": {
            "name": {
              "type": "string",
              "description": "Name of the widget to add."
            },
            "quantity": {
              "type": "integer",
              "description": "Qauntity of the widget to add."
            }
          },
          "required": [
            "name",
            "quantity"
          ]
        }
      }
    },
    "required": [
      "widgets"
    ]
  }
}
```

The current version (1.4.0) doesn't support this. There is no "object" data type on the `PropertyDetails` struct.

However, the `FunctionParameters` struct implements an "object" data type, since the Gemini API requires the top-level parameters to be passed in a `parameters` object.

I have merged the behaviours of these into a new `FunctionParameter` struct.

The first issue that arose was the possibility of adding an object property to a non-object datatype, e.g.

```rust
let param = FunctionParameter::string("foo")
               .with_property("name", FunctionParameter::string("bar"), true);
```

I have used a builder for creating objects to solve this. The name `FunctionParameterObjectBuilder` seems very long, but didn't know what else to call it. :-)

