### PR TITLE
Refactor function parameter handling to use Schema type

### DIFF
--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,7 +1,4 @@
-use gemini_rust::{
-    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, Part,
-    PropertyDetails,
-};
+use gemini_rust::{Content, FunctionCallingMode, FunctionDeclaration, Gemini, Part, Schema};
 use std::env;
 
 #[tokio::main]
@@ -15,15 +12,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let get_weather = FunctionDeclaration::new(
         "get_weather",
         "Get the current weather for a location",
-        FunctionParameters::object()
+        Schema::object()
             .with_property(
                 "location",
-                PropertyDetails::string("The city and state, e.g., San Francisco, CA"),
+                Schema::string("The city and state, e.g., San Francisco, CA"),
                 true,
             )
             .with_property(
                 "unit",
-                PropertyDetails::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
+                Schema::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
                 false,
             ),
     );

--- a/examples/google_search_with_functions.rs
+++ b/examples/google_search_with_functions.rs
@@ -1,6 +1,6 @@
 use gemini_rust::{
-    Content, FunctionCall, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini,
-    Message, PropertyDetails, Role, Tool,
+    Content, FunctionCall, FunctionCallingMode, FunctionDeclaration, Gemini, Message, Role, Schema,
+    Tool,
 };
 use serde_json::json;
 use std::env;
@@ -19,28 +19,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let schedule_meeting = FunctionDeclaration::new(
         "schedule_meeting",
         "Schedules a meeting with specified attendees at a given time and date.",
-        FunctionParameters::object()
+        Schema::object()
             .with_property(
                 "attendees",
-                PropertyDetails::array(
+                Schema::array(
                     "List of people attending the meeting.",
-                    PropertyDetails::string("Attendee name"),
+                    Schema::string("Attendee name"),
                 ),
                 true,
             )
             .with_property(
                 "date",
-                PropertyDetails::string("Date of the meeting (e.g., '2024-07-29')"),
+                Schema::string("Date of the meeting (e.g., '2024-07-29')"),
                 true,
             )
             .with_property(
                 "time",
-                PropertyDetails::string("Time of the meeting (e.g., '15:00')"),
+                Schema::string("Time of the meeting (e.g., '15:00')"),
                 true,
             )
             .with_property(
                 "topic",
-                PropertyDetails::string("The subject or topic of the meeting."),
+                Schema::string("The subject or topic of the meeting."),
                 true,
             ),
     );

--- a/examples/nested_schema.rs
+++ b/examples/nested_schema.rs
@@ -1,0 +1,409 @@
+use gemini_rust::{FunctionCallingMode, FunctionDeclaration, Gemini, Message, Schema, Tool};
+use serde_json::json;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Get API key from environment variable
+    let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+
+    // Create client
+    let client = Gemini::new(api_key).expect("unable to create Gemini API client");
+
+    println!("--- Nested Schema Example ---");
+
+    // Create a nested address schema
+    let address_schema = Schema::object()
+        .with_property("street", Schema::string("Street address"), true)
+        .with_property("city", Schema::string("City name"), true)
+        .with_property("state", Schema::string("State or province"), true)
+        .with_property(
+            "postal_code",
+            Schema::string("Postal or ZIP code").with_pattern(r"^\d{5}(-\d{4})?$"),
+            true,
+        )
+        .with_property("country", Schema::string("Country name"), false);
+
+    // Create a contact info schema
+    let contact_schema = Schema::object()
+        .with_property(
+            "email",
+            Schema::string("Email address").with_pattern(r"^[^\s@]+@[^\s@]+\.[^\s@]+$"),
+            true,
+        )
+        .with_property(
+            "phone",
+            Schema::string("Phone number").with_pattern(r"^\+?[\d\s\-\(\)]+$"),
+            false,
+        )
+        .with_property("website", Schema::string("Website URL"), false);
+
+    // Create a preferences schema with enum and nested objects
+    let preferences_schema = Schema::object()
+        .with_property(
+            "communication_method",
+            Schema::enum_type(
+                "Preferred communication method",
+                ["email", "phone", "sms", "mail"],
+            ),
+            true,
+        )
+        .with_property(
+            "notification_settings",
+            Schema::object()
+                .with_property(
+                    "marketing",
+                    Schema::boolean("Receive marketing emails"),
+                    false,
+                )
+                .with_property("updates", Schema::boolean("Receive product updates"), true)
+                .with_property(
+                    "reminders",
+                    Schema::boolean("Receive appointment reminders"),
+                    true,
+                ),
+            false,
+        )
+        .with_property(
+            "languages",
+            Schema::array(
+                "Preferred languages",
+                Schema::string("Language code (e.g., 'en', 'es')"),
+            ),
+            false,
+        );
+
+    // Create a complex user management function with deeply nested schemas
+    let create_user = FunctionDeclaration::new(
+        "create_user",
+        "Create a new user profile with detailed information",
+        Schema::object()
+            .with_property(
+                "personal_info",
+                Schema::object()
+                    .with_property("first_name", Schema::string("First name"), true)
+                    .with_property("last_name", Schema::string("Last name"), true)
+                    .with_property(
+                        "date_of_birth",
+                        Schema::string("Date of birth in YYYY-MM-DD format")
+                            .with_pattern(r"^\d{4}-\d{2}-\d{2}$"),
+                        false,
+                    )
+                    .with_property(
+                        "gender",
+                        Schema::enum_type(
+                            "Gender",
+                            ["male", "female", "non-binary", "prefer-not-to-say"],
+                        ),
+                        false,
+                    ),
+                true,
+            )
+            .with_property("address", address_schema.clone(), true)
+            .with_property("contact", contact_schema, true)
+            .with_property("preferences", preferences_schema, false)
+            .with_property(
+                "tags",
+                Schema::array("User tags for categorization", Schema::string("Tag name")),
+                false,
+            )
+            .with_property(
+                "metadata",
+                Schema::object()
+                    .with_property("source", Schema::string("Registration source"), false)
+                    .with_property("referrer", Schema::string("Referrer information"), false)
+                    .with_property(
+                        "custom_fields",
+                        Schema::object(), // Empty object for custom key-value pairs
+                        false,
+                    ),
+                false,
+            ),
+    );
+
+    // Create another function that uses array of objects
+    let search_users = FunctionDeclaration::new(
+        "search_users",
+        "Search for users based on various criteria",
+        Schema::object()
+            .with_property(
+                "filters",
+                Schema::array(
+                    "Search filters to apply",
+                    Schema::object()
+                        .with_property("field", Schema::string("Field name to filter on"), true)
+                        .with_property(
+                            "operator",
+                            Schema::enum_type(
+                                "Comparison operator",
+                                [
+                                    "equals",
+                                    "contains",
+                                    "starts_with",
+                                    "greater_than",
+                                    "less_than",
+                                ],
+                            ),
+                            true,
+                        )
+                        .with_property("value", Schema::string("Value to compare against"), true),
+                ),
+                true,
+            )
+            .with_property(
+                "sort",
+                Schema::object()
+                    .with_property("field", Schema::string("Field to sort by"), true)
+                    .with_property(
+                        "direction",
+                        Schema::enum_type("Sort direction", ["asc", "desc"]),
+                        false,
+                    ),
+                false,
+            )
+            .with_property(
+                "pagination",
+                Schema::object()
+                    .with_property(
+                        "page",
+                        Schema::integer("Page number (1-based)").with_range(Some(1.0), None),
+                        false,
+                    )
+                    .with_property(
+                        "limit",
+                        Schema::integer("Items per page").with_range(Some(1.0), Some(100.0)),
+                        false,
+                    ),
+                false,
+            ),
+    );
+
+    // Create a function that demonstrates complex response schema
+    let get_user_analytics = FunctionDeclaration::new(
+        "get_user_analytics",
+        "Get detailed analytics for user engagement",
+        Schema::object()
+            .with_property("user_id", Schema::string("User identifier"), true)
+            .with_property(
+                "date_range",
+                Schema::object()
+                    .with_property(
+                        "start_date",
+                        Schema::string("Start date (YYYY-MM-DD)"),
+                        true,
+                    )
+                    .with_property("end_date", Schema::string("End date (YYYY-MM-DD)"), true),
+                true,
+            )
+            .with_property(
+                "metrics",
+                Schema::array(
+                    "Metrics to include in the report",
+                    Schema::enum_type(
+                        "Available metrics",
+                        [
+                            "page_views",
+                            "session_duration",
+                            "bounce_rate",
+                            "conversion_rate",
+                            "click_through_rate",
+                            "engagement_score",
+                        ],
+                    ),
+                ),
+                false,
+            ),
+    )
+    .with_response(
+        Schema::object()
+            .with_property("user_id", Schema::string("User identifier"), true)
+            .with_property(
+                "analytics",
+                Schema::object()
+                    .with_property(
+                        "summary",
+                        Schema::object()
+                            .with_property(
+                                "total_sessions",
+                                Schema::integer("Total number of sessions"),
+                                true,
+                            )
+                            .with_property(
+                                "average_session_duration",
+                                Schema::number("Average session duration in minutes"),
+                                true,
+                            )
+                            .with_property(
+                                "total_page_views",
+                                Schema::integer("Total page views"),
+                                true,
+                            ),
+                        true,
+                    )
+                    .with_property(
+                        "daily_breakdown",
+                        Schema::array(
+                            "Daily analytics data",
+                            Schema::object()
+                                .with_property("date", Schema::string("Date (YYYY-MM-DD)"), true)
+                                .with_property(
+                                    "sessions",
+                                    Schema::integer("Number of sessions"),
+                                    true,
+                                )
+                                .with_property(
+                                    "page_views",
+                                    Schema::integer("Number of page views"),
+                                    true,
+                                )
+                                .with_property(
+                                    "duration",
+                                    Schema::number("Total session duration"),
+                                    true,
+                                ),
+                        ),
+                        true,
+                    )
+                    .with_property(
+                        "conversion_funnel",
+                        Schema::array(
+                            "Conversion funnel stages",
+                            Schema::object()
+                                .with_property("stage", Schema::string("Funnel stage name"), true)
+                                .with_property(
+                                    "users",
+                                    Schema::integer("Number of users at this stage"),
+                                    true,
+                                )
+                                .with_property(
+                                    "conversion_rate",
+                                    Schema::number("Conversion rate to next stage"),
+                                    false,
+                                ),
+                        ),
+                        false,
+                    ),
+                true,
+            )
+            .with_property(
+                "generated_at",
+                Schema::string("Report generation timestamp"),
+                true,
+            ),
+    );
+
+    // Create a tool with all the nested schema functions
+    let user_management_tool =
+        Tool::with_functions(vec![create_user, search_users, get_user_analytics]);
+
+    // Create a request to demonstrate the nested schemas
+    let response = client
+        .generate_content()
+        .with_system_prompt(
+            "You are a helpful assistant that can manage user profiles and analytics. \
+            When asked to create a user profile, use the provided information to call \
+            the create_user function with all the appropriate nested data structures."
+        )
+        .with_user_message(
+            "I want to create a comprehensive user profile for John Doe. \
+            He lives at 123 Main St, San Francisco, CA 94102, USA. \
+            His email is john.doe@example.com and phone is +1-555-123-4567. \
+            He prefers email communication, wants product updates but no marketing emails. \
+            He speaks English and Spanish. Please create his profile with appropriate tags and metadata."
+        )
+        .with_tool(user_management_tool.clone())
+        .with_function_calling_mode(FunctionCallingMode::Any)
+        .execute()
+        .await?;
+
+    // Execute the request
+    println!("\nSending request with nested schema functions...");
+
+    // Process function calls
+    if let Some(function_call) = response.function_calls().first() {
+        println!("Function Call: {}", function_call.name);
+        println!("Arguments (showing nested schema structure):");
+        println!("{}", serde_json::to_string_pretty(&function_call.args)?);
+
+        // Simulate function execution for create_user
+        if function_call.name == "create_user" {
+            let mock_response = json!({
+                "user_id": "user_12345",
+                "status": "created",
+                "message": "User profile created successfully with nested data structure",
+                "profile": {
+                    "personal_info": {
+                        "first_name": "John",
+                        "last_name": "Doe"
+                    },
+                    "address": {
+                        "street": "123 Main St",
+                        "city": "San Francisco",
+                        "state": "CA",
+                        "postal_code": "94102",
+                        "country": "USA"
+                    },
+                    "contact": {
+                        "email": "john.doe@example.com",
+                        "phone": "+1-555-123-4567"
+                    },
+                    "preferences": {
+                        "communication_method": "email",
+                        "notification_settings": {
+                            "marketing": false,
+                            "updates": true,
+                            "reminders": true
+                        },
+                        "languages": ["en", "es"]
+                    },
+                    "tags": ["new_user", "multilingual"],
+                    "metadata": {
+                        "source": "manual_creation",
+                        "created_at": "2024-01-15T10:30:00Z"
+                    }
+                }
+            });
+
+            println!("\nMock function response (demonstrating nested response structure):");
+            println!("{}", serde_json::to_string_pretty(&mock_response)?);
+
+            // Send function response back to continue conversation
+            let followup_response = client
+                .generate_content()
+                .with_system_prompt(
+                    "You are a helpful assistant that can manage user profiles and analytics."
+                )
+                .with_user_message(
+                    "I want to create a comprehensive user profile for John Doe. \
+                    He lives at 123 Main St, San Francisco, CA 94102, USA. \
+                    His email is john.doe@example.com and phone is +1-555-123-4567. \
+                    He prefers email communication, wants product updates but no marketing emails. \
+                    He speaks English and Spanish. Please create his profile with appropriate tags and metadata."
+                )
+                .with_tool(user_management_tool.clone())
+                .with_message(Message {
+                    content: gemini_rust::Content::function_call((*function_call).clone()),
+                    role: gemini_rust::Role::Model,
+                })
+                .with_function_response_str(&function_call.name, mock_response.to_string())?
+                .execute()
+                .await?;
+
+            println!("\nFinal Response: {}", followup_response.text());
+        }
+    } else {
+        println!("Response: {}", response.text());
+    }
+
+    println!("\n--- Nested Schema Example completed ---");
+    println!("This example demonstrates:");
+    println!("1. Nested object schemas (address, contact, preferences)");
+    println!("2. Array schemas with complex item types");
+    println!("3. Enum schemas for constrained values");
+    println!("4. Schema validation with patterns (regex)");
+    println!("5. Range validation for numbers");
+    println!("6. Complex response schemas");
+    println!("7. Multiple levels of nesting in function parameters");
+
+    Ok(())
+}

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use gemini_rust::{
-    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini,
-    GenerationConfig, Message, PropertyDetails, Role,
+    Content, FunctionCallingMode, FunctionDeclaration, Gemini, GenerationConfig, Message, Role,
+    Schema,
 };
 use std::env;
 
@@ -34,15 +34,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let get_weather = FunctionDeclaration::new(
         "get_weather",
         "Get the current weather for a location",
-        FunctionParameters::object()
+        Schema::object()
             .with_property(
                 "location",
-                PropertyDetails::string("The city and state, e.g., San Francisco, CA"),
+                Schema::string("The city and state, e.g., San Francisco, CA"),
                 true,
             )
             .with_property(
                 "unit",
-                PropertyDetails::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
+                Schema::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
                 false,
             ),
     );

--- a/examples/simple_thought_signature.rs
+++ b/examples/simple_thought_signature.rs
@@ -1,7 +1,4 @@
-use gemini_rust::{
-    FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails,
-    ThinkingConfig, Tool,
-};
+use gemini_rust::{FunctionCallingMode, FunctionDeclaration, Gemini, Schema, ThinkingConfig, Tool};
 use std::env;
 
 #[tokio::main]
@@ -13,11 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let weather_function = FunctionDeclaration::new(
         "get_weather",
         "Get current weather for a location",
-        FunctionParameters::object().with_property(
-            "location",
-            PropertyDetails::string("City name"),
-            true,
-        ),
+        Schema::object().with_property("location", Schema::string("City name"), true),
     );
 
     // Configure thinking to enable thoughtSignature

--- a/examples/thinking_advanced.rs
+++ b/examples/thinking_advanced.rs
@@ -1,7 +1,5 @@
 use futures::TryStreamExt;
-use gemini_rust::{
-    FunctionDeclaration, FunctionParameters, Gemini, PropertyDetails, ThinkingConfig,
-};
+use gemini_rust::{FunctionDeclaration, Gemini, Schema, ThinkingConfig};
 use std::env;
 
 #[tokio::main]
@@ -53,17 +51,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let calculator = FunctionDeclaration::new(
         "calculate",
         "Perform basic mathematical calculations",
-        FunctionParameters::object()
+        Schema::object()
             .with_property(
                 "expression",
-                PropertyDetails::string(
-                    "The mathematical expression to calculate, e.g., '2 + 3 * 4'",
-                ),
+                Schema::string("The mathematical expression to calculate, e.g., '2 + 3 * 4'"),
                 true,
             )
             .with_property(
                 "operation_type",
-                PropertyDetails::enum_type("Type of calculation", ["arithmetic", "advanced"]),
+                Schema::enum_type("Type of calculation", ["arithmetic", "advanced"]),
                 false,
             ),
     );

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -14,8 +14,8 @@
 /// Thought signatures are encrypted representations of the model's internal
 /// thought process that help maintain context across conversation turns.
 use gemini_rust::{
-    FunctionCallingMode, FunctionDeclaration, FunctionParameters, FunctionResponse, Gemini,
-    PropertyDetails, ThinkingConfig, Tool,
+    FunctionCallingMode, FunctionDeclaration, FunctionResponse, Gemini, Schema, ThinkingConfig,
+    Tool,
 };
 use serde_json::json;
 use std::env;
@@ -34,9 +34,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let weather_function = FunctionDeclaration::new(
         "get_current_weather",
         "Get current weather information for a specified location",
-        FunctionParameters::object().with_property(
+        Schema::object().with_property(
             "location",
-            PropertyDetails::string("City and region, e.g., Kaohsiung Zuoying District"),
+            Schema::string("City and region, e.g., Kaohsiung Zuoying District"),
             true,
         ),
     );
@@ -187,9 +187,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let weather_tool_followup = Tool::new(FunctionDeclaration::new(
                 "get_current_weather",
                 "Get current weather information for a specified location",
-                FunctionParameters::object().with_property(
+                Schema::object().with_property(
                     "location",
-                    PropertyDetails::string("City and region, e.g., Kaohsiung Zuoying District"),
+                    Schema::string("City and region, e.g., Kaohsiung Zuoying District"),
                     true,
                 ),
             ));

--- a/examples/tools.rs
+++ b/examples/tools.rs
@@ -1,6 +1,5 @@
 use gemini_rust::{
-    Content, FunctionCallingMode, FunctionDeclaration, FunctionParameters, Gemini, Message,
-    PropertyDetails, Role, Tool,
+    Content, FunctionCallingMode, FunctionDeclaration, Gemini, Message, Role, Schema, Tool,
 };
 use serde_json::json;
 use std::env;
@@ -19,15 +18,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let get_weather = FunctionDeclaration::new(
         "get_weather",
         "Get the current weather for a location",
-        FunctionParameters::object()
+        Schema::object()
             .with_property(
                 "location",
-                PropertyDetails::string("The city and state, e.g., San Francisco, CA"),
+                Schema::string("The city and state, e.g., San Francisco, CA"),
                 true,
             )
             .with_property(
                 "unit",
-                PropertyDetails::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
+                Schema::enum_type("The unit of temperature", ["celsius", "fahrenheit"]),
                 false,
             ),
     );
@@ -36,17 +35,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let calculate = FunctionDeclaration::new(
         "calculate",
         "Perform a calculation",
-        FunctionParameters::object()
+        Schema::object()
             .with_property(
                 "operation",
-                PropertyDetails::enum_type(
+                Schema::enum_type(
                     "The mathematical operation to perform",
                     ["add", "subtract", "multiply", "divide"],
                 ),
                 true,
             )
-            .with_property("a", PropertyDetails::number("The first number"), true)
-            .with_property("b", PropertyDetails::number("The second number"), true),
+            .with_property("a", Schema::number("The first number"), true)
+            .with_property("b", Schema::number("The second number"), true),
     );
 
     // Create a tool with multiple functions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,8 +108,8 @@ pub use safety::model::{
 // Types for integrating external tools and function calling
 
 pub use tools::model::{
-    FunctionCall, FunctionCallingConfig, FunctionCallingMode, FunctionDeclaration,
-    FunctionParameters, FunctionResponse, PropertyDetails, Tool, ToolConfig,
+    FunctionBehavior, FunctionCall, FunctionCallingConfig, FunctionCallingMode,
+    FunctionDeclaration, FunctionResponse, Schema, SchemaType, Tool, ToolConfig,
 };
 
 // ========== Batch Processing ==========

--- a/src/tools/model.rs
+++ b/src/tools/model.rs
@@ -52,8 +52,33 @@ pub struct FunctionDeclaration {
     pub name: String,
     /// The description of the function
     pub description: String,
-    /// The parameters for the function
-    pub parameters: FunctionParameters,
+    /// The parameters for the function (using OpenAPI 3.0 Schema)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters: Option<Schema>,
+    /// JSON Schema format parameters (mutually exclusive with parameters)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameters_json_schema: Option<serde_json::Value>,
+    /// The response schema (using OpenAPI 3.0 Schema)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<Schema>,
+    /// JSON Schema format response (mutually exclusive with response)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_json_schema: Option<serde_json::Value>,
+    /// Function behavior (BLOCKING or NON_BLOCKING)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub behavior: Option<FunctionBehavior>,
+}
+
+/// Function behavior configuration
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum FunctionBehavior {
+    /// This value is unused
+    Unspecified,
+    /// The system will wait to receive the function response before continuing
+    Blocking,
+    /// The system will not wait to receive the function response
+    NonBlocking,
 }
 
 impl FunctionDeclaration {
@@ -61,50 +86,359 @@ impl FunctionDeclaration {
     pub fn new(
         name: impl Into<String>,
         description: impl Into<String>,
-        parameters: FunctionParameters,
+        parameters: Schema,
     ) -> Self {
         Self {
             name: name.into(),
             description: description.into(),
-            parameters,
+            parameters: Some(parameters),
+            parameters_json_schema: None,
+            response: None,
+            response_json_schema: None,
+            behavior: None,
         }
+    }
+
+    /// Create a new function declaration with JSON schema parameters
+    pub fn with_json_schema_parameters(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters_json_schema: serde_json::Value,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            parameters: None,
+            parameters_json_schema: Some(parameters_json_schema),
+            response: None,
+            response_json_schema: None,
+            behavior: None,
+        }
+    }
+
+    /// Set the response schema
+    pub fn with_response(mut self, response: Schema) -> Self {
+        self.response = Some(response);
+        self
+    }
+
+    /// Set the response JSON schema
+    pub fn with_response_json_schema(mut self, response_json_schema: serde_json::Value) -> Self {
+        self.response_json_schema = Some(response_json_schema);
+        self
+    }
+
+    /// Set the function behavior
+    pub fn with_behavior(mut self, behavior: FunctionBehavior) -> Self {
+        self.behavior = Some(behavior);
+        self
     }
 }
 
-/// Parameters for a function
+/// Schema data type according to OpenAPI 3.0 specification
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct FunctionParameters {
-    /// The type of the parameters
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum SchemaType {
+    /// Not specified, should not be used
+    TypeUnspecified,
+    /// String type
+    String,
+    /// Number type
+    Number,
+    /// Integer type
+    Integer,
+    /// Boolean type
+    Boolean,
+    /// Array type
+    Array,
+    /// Object type
+    Object,
+    /// Null type
+    Null,
+}
+
+/// Schema object following OpenAPI 3.0 specification
+/// Represents both function parameters and property details
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Schema {
+    /// Required. Data type
     #[serde(rename = "type")]
-    pub param_type: String,
-    /// The properties of the parameters
+    pub schema_type: SchemaType,
+    /// Optional. The format of the data
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub properties: Option<HashMap<String, PropertyDetails>>,
-    /// The required properties
+    pub format: Option<String>,
+    /// Optional. The title of the schema
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Optional. A brief description of the parameter
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional. Indicates if the value may be null
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nullable: Option<bool>,
+    /// Optional. Possible values for enum types
+    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
+    pub enum_values: Option<Vec<String>>,
+    /// Optional. Schema of array elements
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub items: Option<Box<Schema>>,
+    /// Optional. Maximum number of array elements
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_items: Option<i64>,
+    /// Optional. Minimum number of array elements
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_items: Option<i64>,
+    /// Optional. Properties of object type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub properties: Option<HashMap<String, Schema>>,
+    /// Optional. Required properties of object type
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<Vec<String>>,
+    /// Optional. Minimum number of object properties
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_properties: Option<i64>,
+    /// Optional. Maximum number of object properties
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_properties: Option<i64>,
+    /// Optional. Minimum value for integer and number types
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum: Option<f64>,
+    /// Optional. Maximum value for integer and number types
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum: Option<f64>,
+    /// Optional. Minimum length for string type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_length: Option<i64>,
+    /// Optional. Maximum length for string type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_length: Option<i64>,
+    /// Optional. Pattern for string type validation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
+    /// Optional. Example of the object
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<serde_json::Value>,
+    /// Optional. The value should be validated against any of the subschemas
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub any_of: Option<Vec<Schema>>,
+    /// Optional. Property ordering
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub property_ordering: Option<Vec<String>>,
+    /// Optional. Default value
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
 }
 
-impl FunctionParameters {
-    /// Create a new object parameter set
+impl Schema {
+    /// Create a new object schema
     pub fn object() -> Self {
         Self {
-            param_type: "object".to_string(),
+            schema_type: SchemaType::Object,
+            format: None,
+            title: None,
+            description: None,
+            nullable: None,
+            enum_values: None,
+            items: None,
+            max_items: None,
+            min_items: None,
             properties: Some(HashMap::new()),
             required: Some(Vec::new()),
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
         }
     }
 
-    /// Add a property to the parameters
+    /// Create a new string schema
+    pub fn string(description: impl Into<String>) -> Self {
+        Self {
+            schema_type: SchemaType::String,
+            format: None,
+            title: None,
+            description: Some(description.into()),
+            nullable: None,
+            enum_values: None,
+            items: None,
+            max_items: None,
+            min_items: None,
+            properties: None,
+            required: None,
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
+        }
+    }
+
+    /// Create a new number schema
+    pub fn number(description: impl Into<String>) -> Self {
+        Self {
+            schema_type: SchemaType::Number,
+            format: None,
+            title: None,
+            description: Some(description.into()),
+            nullable: None,
+            enum_values: None,
+            items: None,
+            max_items: None,
+            min_items: None,
+            properties: None,
+            required: None,
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
+        }
+    }
+
+    /// Create a new integer schema
+    pub fn integer(description: impl Into<String>) -> Self {
+        Self {
+            schema_type: SchemaType::Integer,
+            format: None,
+            title: None,
+            description: Some(description.into()),
+            nullable: None,
+            enum_values: None,
+            items: None,
+            max_items: None,
+            min_items: None,
+            properties: None,
+            required: None,
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
+        }
+    }
+
+    /// Create a new boolean schema
+    pub fn boolean(description: impl Into<String>) -> Self {
+        Self {
+            schema_type: SchemaType::Boolean,
+            format: None,
+            title: None,
+            description: Some(description.into()),
+            nullable: None,
+            enum_values: None,
+            items: None,
+            max_items: None,
+            min_items: None,
+            properties: None,
+            required: None,
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
+        }
+    }
+
+    /// Create a new array schema
+    pub fn array(description: impl Into<String>, items: Schema) -> Self {
+        Self {
+            schema_type: SchemaType::Array,
+            format: None,
+            title: None,
+            description: Some(description.into()),
+            nullable: None,
+            enum_values: None,
+            items: Some(Box::new(items)),
+            max_items: None,
+            min_items: None,
+            properties: None,
+            required: None,
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
+        }
+    }
+
+    /// Create a new enum schema
+    pub fn enum_type(
+        description: impl Into<String>,
+        enum_values: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        Self {
+            schema_type: SchemaType::String,
+            format: Some("enum".to_string()),
+            title: None,
+            description: Some(description.into()),
+            nullable: None,
+            enum_values: Some(enum_values.into_iter().map(|s| s.into()).collect()),
+            items: None,
+            max_items: None,
+            min_items: None,
+            properties: None,
+            required: None,
+            min_properties: None,
+            max_properties: None,
+            minimum: None,
+            maximum: None,
+            min_length: None,
+            max_length: None,
+            pattern: None,
+            example: None,
+            any_of: None,
+            property_ordering: None,
+            default: None,
+        }
+    }
+
+    /// Add a property to an object schema
     pub fn with_property(
         mut self,
         name: impl Into<String>,
-        details: PropertyDetails,
+        schema: Schema,
         required: bool,
     ) -> Self {
         let name = name.into();
         if let Some(props) = &mut self.properties {
-            props.insert(name.clone(), details);
+            props.insert(name.clone(), schema);
         }
         if required {
             if let Some(req) = &mut self.required {
@@ -113,87 +447,55 @@ impl FunctionParameters {
         }
         self
     }
-}
 
-/// Details about a property
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct PropertyDetails {
-    /// The type of the property
-    #[serde(rename = "type")]
-    pub property_type: String,
-    /// The description of the property
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// The enum values if the property is an enum
-    #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
-    pub enum_values: Option<Vec<String>>,
-    /// The items if the property is an array
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<Box<PropertyDetails>>,
-}
-
-impl PropertyDetails {
-    /// Create a new string property
-    pub fn string(description: impl Into<String>) -> Self {
-        Self {
-            property_type: "string".to_string(),
-            description: Some(description.into()),
-            enum_values: None,
-            items: None,
-        }
+    /// Set the format field
+    pub fn with_format(mut self, format: impl Into<String>) -> Self {
+        self.format = Some(format.into());
+        self
     }
 
-    /// Create a new number property
-    pub fn number(description: impl Into<String>) -> Self {
-        Self {
-            property_type: "number".to_string(),
-            description: Some(description.into()),
-            enum_values: None,
-            items: None,
-        }
+    /// Set the title field
+    pub fn with_title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
     }
 
-    /// Create a new integer property
-    pub fn integer(description: impl Into<String>) -> Self {
-        Self {
-            property_type: "integer".to_string(),
-            description: Some(description.into()),
-            enum_values: None,
-            items: None,
-        }
+    /// Set nullable
+    pub fn with_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = Some(nullable);
+        self
     }
 
-    /// Create a new boolean property
-    pub fn boolean(description: impl Into<String>) -> Self {
-        Self {
-            property_type: "boolean".to_string(),
-            description: Some(description.into()),
-            enum_values: None,
-            items: None,
-        }
+    /// Set minimum and maximum for number/integer types
+    pub fn with_range(mut self, min: Option<f64>, max: Option<f64>) -> Self {
+        self.minimum = min;
+        self.maximum = max;
+        self
     }
 
-    /// Create a new array property
-    pub fn array(description: impl Into<String>, items: PropertyDetails) -> Self {
-        Self {
-            property_type: "array".to_string(),
-            description: Some(description.into()),
-            enum_values: None,
-            items: Some(Box::new(items)),
-        }
+    /// Set min_length and max_length for string types
+    pub fn with_length_range(mut self, min_length: Option<i64>, max_length: Option<i64>) -> Self {
+        self.min_length = min_length;
+        self.max_length = max_length;
+        self
     }
 
-    /// Create a new enum property
-    pub fn enum_type(
-        description: impl Into<String>,
-        enum_values: impl IntoIterator<Item = impl Into<String>>,
-    ) -> Self {
-        Self {
-            property_type: "string".to_string(),
-            description: Some(description.into()),
-            enum_values: Some(enum_values.into_iter().map(|s| s.into()).collect()),
-            items: None,
-        }
+    /// Set pattern for string validation
+    pub fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.pattern = Some(pattern.into());
+        self
+    }
+
+    /// Set example value
+    pub fn with_example(mut self, example: serde_json::Value) -> Self {
+        self.example = Some(example);
+        self
+    }
+
+    /// Set default value
+    pub fn with_default(mut self, default: serde_json::Value) -> Self {
+        self.default = Some(default);
+        self
     }
 }
 /// A function call made by the model


### PR DESCRIPTION
This pull request refactors the function parameter and property schema handling across all example files to use a unified `Schema` API instead of the older `FunctionParameters` and `PropertyDetails` types. This results in more consistent and streamlined code for defining function signatures and their properties.

**Refactoring to unified schema API:**

* All examples now use `Schema` and its methods (e.g., `Schema::object()`, `Schema::string()`, `Schema::enum_type()`, `Schema::number()`, `Schema::array()`) for defining function parameters and property types, replacing the previous use of `FunctionParameters` and `PropertyDetails`. [[1]](diffhunk://#diff-46e29778ff7a7a5738af3c94b368b00dee7711412f86205134dc61953c75531dL1-R1) [[2]](diffhunk://#diff-46e29778ff7a7a5738af3c94b368b00dee7711412f86205134dc61953c75531dL18-R23) [[3]](diffhunk://#diff-4a220e104c3f96911b10d992a531a806850c5e0da2286be849dd4716e49ccfc8L2-R3) [[4]](diffhunk://#diff-4a220e104c3f96911b10d992a531a806850c5e0da2286be849dd4716e49ccfc8L22-R43) [[5]](diffhunk://#diff-9b91ae38610593e55d5bf8c7f39f99538733db009291ac6ed4ec9a6664e75fbbL2-R3) [[6]](diffhunk://#diff-9b91ae38610593e55d5bf8c7f39f99538733db009291ac6ed4ec9a6664e75fbbL37-R45) [[7]](diffhunk://#diff-3d820a9df40634688084d02b12befc6e3606e5958ed425dd986654adc0b2d660L1-R1) [[8]](diffhunk://#diff-3d820a9df40634688084d02b12befc6e3606e5958ed425dd986654adc0b2d660L16-R13) [[9]](diffhunk://#diff-955929136ba5fec2b6dc06c63d5510e440abfe7a2bba9977168d3ba29a2e2045L2-R2) [[10]](diffhunk://#diff-955929136ba5fec2b6dc06c63d5510e440abfe7a2bba9977168d3ba29a2e2045L56-R62) [[11]](diffhunk://#diff-f4a9e265d8755f88aa1394dd95ae1281c8980c68a0b9f29990b1fd71bb5be691L17-R18) [[12]](diffhunk://#diff-f4a9e265d8755f88aa1394dd95ae1281c8980c68a0b9f29990b1fd71bb5be691L37-R39) [[13]](diffhunk://#diff-f4a9e265d8755f88aa1394dd95ae1281c8980c68a0b9f29990b1fd71bb5be691L190-R192) [[14]](diffhunk://#diff-58ee738925ce793fd72b36afe0766fa1ff44391828aacfab8fea612eb6bd6891L2-R2) [[15]](diffhunk://#diff-58ee738925ce793fd72b36afe0766fa1ff44391828aacfab8fea612eb6bd6891L22-R29) [[16]](diffhunk://#diff-58ee738925ce793fd72b36afe0766fa1ff44391828aacfab8fea612eb6bd6891L39-R48)

**Public API update:**

* The library's public API (`src/lib.rs`) now re-exports the new `Schema` and `SchemaType` types, and removes the deprecated `FunctionParameters` and `PropertyDetails` from the exports.