### PR TITLE
Add `Clone` derive to all builder types

### DIFF
--- a/src/batch/builder.rs
+++ b/src/batch/builder.rs
@@ -12,6 +12,7 @@ use crate::{client::GeminiClient, generation::GenerateContentRequest};
 /// This builder simplifies the process of constructing a batch request, allowing you to
 /// add multiple `GenerateContentRequest` items and then execute them as a single
 /// long-running operation.
+#[derive(Clone)]
 pub struct BatchBuilder {
     client: Arc<GeminiClient>,
     display_name: String,

--- a/src/cache/builder.rs
+++ b/src/cache/builder.rs
@@ -15,6 +15,7 @@ use crate::tools::Tool;
 use crate::tools::ToolConfig;
 
 /// Builder for creating cached content with a fluent API.
+#[derive(Clone)]
 pub struct CacheBuilder {
     client: Arc<GeminiClient>,
     display_name: Option<String>,

--- a/src/embedding/builder.rs
+++ b/src/embedding/builder.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 
 /// Builder for embed generation requests
+#[derive(Clone)]
 pub struct EmbedBuilder {
     client: Arc<GeminiClient>,
     contents: Vec<Content>,

--- a/src/files/builder.rs
+++ b/src/files/builder.rs
@@ -7,6 +7,7 @@ use super::*;
 use crate::client::GeminiClient;
 
 /// A builder for creating a file resource.
+#[derive(Clone)]
 pub struct FileBuilder {
     client: Arc<GeminiClient>,
     file_bytes: Vec<u8>,

--- a/src/generation/builder.rs
+++ b/src/generation/builder.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 /// Builder for content generation requests
+#[derive(Clone)]
 pub struct ContentBuilder {
     client: Arc<GeminiClient>,
     pub contents: Vec<Content>,


### PR DESCRIPTION
Hi, thanks for the great crate!

This PR adds `#[derive(Clone)]` to all builder types (`BatchBuilder`, `CacheBuilder`, `EmbedBuilder`, `FileBuilder`, and `ContentBuilder`).

**Motivation:**

When working with builders that share common configuration (system prompts, temperature, tools, etc.), it's useful to be able to clone a pre-configured builder rather than re-initializing it each time.

**Example use case:**

```rust
// Configure once
let base_builder = gemini
    .generate_content()
    .with_system_prompt("You are a helpful assistant")
    .with_temperature(0.7)
    .with_tools(my_tools);

// Clone and use multiple times
let response1 = base_builder.clone()
    .with_contents(user_message_1)
    .execute()
    .await?;

let response2 = base_builder.clone()
    .with_contents(user_message_2)
    .execute()
    .await?;
```

Since all builders use `Arc<GeminiClient>` internally, cloning is cheap (just reference counting) and doesn't duplicate the client.

Do you think it might be useful?