### PR TITLE
feat: add Google Maps grounding support with examples and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A comprehensive Rust client library for Google's Gemini 2.5 API.
 ## ✨ Features
 
 - **🚀 Complete Gemini 2.5 API Implementation** - Full support for all Gemini API endpoints
-- **🛠️ Function Calling & Tools** - Custom functions and Google Search integration with OpenAPI schema support
+- **🛠️ Function Calling & Tools** - Custom functions, Google Search, and Google Maps integration with OpenAPI schema support
+- **🗺️ Google Maps Grounding** - Location-aware responses with Google Maps data and widget support
 - **📦 Batch Processing** - Efficient batch content generation and embedding
 - **💾 Content Caching** - Cache system instructions and conversation history for cost optimization
 - **🔄 Streaming Responses** - Real-time streaming of generated content
@@ -42,6 +43,10 @@ Get started with simple text generation, system prompts, and conversations. See 
 
 Enable real-time content streaming for interactive applications. See [`basic_streaming.rs`](examples/basic_streaming.rs) for examples of processing content as it's generated with immediate display.
 
+### Google Maps Grounding
+
+Add location-aware capabilities to your applications with Google Maps integration. See [`simple_maps_example.rs`](examples/simple_maps_example.rs) for basic usage and [`google_maps_grounding.rs`](examples/google_maps_grounding.rs) for comprehensive examples.
+
 ## 🛠️ Key Features
 
 The library provides comprehensive access to all Gemini 2.5 capabilities through an intuitive Rust API:
@@ -54,8 +59,17 @@ Advanced reasoning capabilities with thought process visibility and custom think
 
 - Custom function declarations with OpenAPI schema support (using `schemars`)
 - Google Search integration for real-time information
+- Google Maps grounding for location-aware responses
 - Type-safe function definitions with automatic schema generation
-- See [`tools.rs`](examples/tools.rs) and [`complex_function.rs`](examples/complex_function.rs)
+- See [`tools.rs`](examples/tools.rs), [`complex_function.rs`](examples/complex_function.rs), and [`google_maps_grounding.rs`](examples/google_maps_grounding.rs)
+
+### 🗺️ **Google Maps Grounding**
+
+- **Location-Aware Responses**: Access Google Maps data for geographically specific queries
+- **Widget Support**: Generate context tokens for interactive Google Maps widgets
+- **Grounding Sources**: Access citation information for all Maps data used in responses
+- **Easy Integration**: Simple API with location context configuration
+- See [`simple_maps_example.rs`](examples/simple_maps_example.rs) and [`advanced_maps_configuration.rs`](examples/advanced_maps_configuration.rs)
 
 ### 🎨 **Multimodal Generation**
 

--- a/examples/advanced_maps_configuration.rs
+++ b/examples/advanced_maps_configuration.rs
@@ -1,0 +1,202 @@
+//! Advanced Google Maps Configuration Example
+//!
+//! This example demonstrates advanced configuration options for Google Maps grounding,
+//! including manual tool configuration and widget support.
+
+use gemini_rust::prelude::*;
+use gemini_rust::{LatLng, RetrievalConfig, Tool, ToolConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the Gemini client
+    let gemini = Gemini::pro(std::env::var("GEMINI_API_KEY")?)?;
+
+    println!("🔧 Advanced Google Maps Configuration Example\n");
+
+    // Example 1: Manual tool configuration
+    manual_tool_configuration(&gemini).await?;
+
+    println!("\n{}\n", "=".repeat(60));
+
+    // Example 2: Widget-enabled Maps grounding
+    widget_enabled_grounding(&gemini).await?;
+
+    println!("\n{}\n", "=".repeat(60));
+
+    // Example 3: Comparison with and without location context
+    location_comparison(&gemini).await?;
+
+    Ok(())
+}
+
+/// Example 1: Manual Google Maps configuration with location context
+async fn manual_tool_configuration(gemini: &Gemini) -> Result<(), Box<dyn std::error::Error>> {
+    println!("📋 Example 1: Manual Tool Configuration");
+
+    let prompt = "Find me vegan restaurants within a 10-minute drive.";
+
+    // Manually create the tool and configuration
+    let tool = Tool::google_maps(None); // No widget
+    let tool_config = ToolConfig {
+        retrieval_config: Some(RetrievalConfig {
+            lat_lng: Some(LatLng::new(40.7128, -74.0060)), // New York City
+        }),
+        function_calling_config: None,
+    };
+
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(tool)
+        .with_tool_config(tool_config)
+        .execute()
+        .await?;
+
+    println!("Query: {}\n", prompt);
+    println!("Response: {}", response.text());
+
+    display_grounding_info(&response);
+
+    Ok(())
+}
+
+/// Example 2: Google Maps grounding with widget support
+async fn widget_enabled_grounding(gemini: &Gemini) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🗺️  Example 2: Widget-Enabled Grounding");
+
+    let prompt = "Plan a food tour of downtown Chicago. Include 3-4 different types of cuisine.";
+
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(Some(true))) // With widget enabled
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(41.8781, -87.6298)), // Chicago
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    println!("Query: {}\n", prompt);
+    println!("Response: {}", response.text());
+
+    display_grounding_info(&response);
+
+    // Check for widget context token
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(widget_token) = &grounding_metadata.google_maps_widget_context_token {
+                println!("\n🎯 Widget Context Token Available:");
+                println!(
+                    "  Token: {}...",
+                    &widget_token[..50.min(widget_token.len())]
+                );
+                println!("  Use this token to render an interactive Google Maps widget:");
+                println!(
+                    "  <gmp-place-contextual context-token=\"{}\"></gmp-place-contextual>",
+                    widget_token
+                );
+            } else {
+                println!("\nℹ️  No widget context token in this response.");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 3: Compare responses with and without location context
+async fn location_comparison(gemini: &Gemini) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔍 Example 3: Location Context Comparison");
+
+    let prompt = "What are some popular brunch spots?";
+
+    // Query without location context
+    println!("❌ WITHOUT location context:");
+    let response_no_location = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .execute()
+        .await?;
+
+    println!("Response: {}", response_no_location.text());
+    check_for_grounding(&response_no_location);
+
+    println!("\n---\n");
+
+    // Query with location context and Google Maps
+    println!("✅ WITH location context (Seattle):");
+    let response_with_location = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(None)) // No widget
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(47.6062, -122.3321)), // Seattle
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    println!("Response: {}", response_with_location.text());
+    check_for_grounding(&response_with_location);
+
+    Ok(())
+}
+
+/// Helper function to display grounding information
+fn display_grounding_info(response: &GenerationResponse) {
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("\n📍 Grounding Sources:");
+                for (i, chunk) in chunks.iter().enumerate() {
+                    if let Some(maps) = &chunk.maps {
+                        println!("  {}. {} - {}", i + 1, maps.title, maps.uri);
+                    } else if let Some(web) = &chunk.web {
+                        println!("  {}. {} - {}", i + 1, web.title, web.uri);
+                    }
+                }
+            }
+
+            if let Some(supports) = &grounding_metadata.grounding_supports {
+                println!("\n🔗 Grounding Supports:");
+                for support in supports {
+                    println!(
+                        "  • \"{}\" -> {:?}",
+                        support.segment.text, support.grounding_chunk_indices
+                    );
+                }
+            }
+
+            if let Some(queries) = &grounding_metadata.web_search_queries {
+                println!("\n🔍 Search Queries:");
+                for query in queries {
+                    println!("  • {}", query);
+                }
+            }
+        } else {
+            println!("\nℹ️  No grounding metadata available.");
+        }
+    }
+}
+
+/// Helper function to check for grounding in responses
+fn check_for_grounding(response: &GenerationResponse) {
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("  ✅ Grounded with {} source(s)", chunks.len());
+            } else {
+                println!("  ❌ No grounding sources");
+            }
+        } else {
+            println!("  ❌ No grounding metadata");
+        }
+    } else {
+        println!("  ❌ No candidates in response");
+    }
+}

--- a/examples/google_maps_grounding.rs
+++ b/examples/google_maps_grounding.rs
@@ -1,0 +1,253 @@
+//! Google Maps Grounding Examples
+//!
+//! This example demonstrates how to use the Google Maps grounding functionality
+//! in the gemini-rust library to provide location-aware responses.
+
+use gemini_rust::prelude::*;
+use gemini_rust::{LatLng, RetrievalConfig, Tool, ToolConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the Gemini client
+    let gemini = Gemini::pro(std::env::var("GEMINI_API_KEY")?)?;
+
+    println!("=== Google Maps Grounding Examples ===\n");
+
+    // Example 1: Basic location-aware restaurant recommendations
+    basic_restaurant_recommendations(&gemini).await?;
+
+    println!("\n{}\n", "=".repeat(50));
+
+    // Example 2: Place-specific question with location context
+    place_specific_question(&gemini).await?;
+
+    println!("\n{}\n", "=".repeat(50));
+
+    // Example 3: Family-friendly recommendations with location
+    family_friendly_recommendations(&gemini).await?;
+
+    println!("\n{}\n", "=".repeat(50));
+
+    // Example 4: Travel itinerary planning with widget support
+    travel_itinerary_planning(&gemini).await?;
+
+    Ok(())
+}
+
+/// Example 1: Basic restaurant recommendations within walking distance
+async fn basic_restaurant_recommendations(
+    gemini: &Gemini,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🍽️  Example 1: Italian Restaurants Within Walking Distance");
+
+    let prompt = "What are the best Italian restaurants within a 15-minute walk from here?";
+
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(None)) // No widget
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(34.050481, -118.248526)), // Los Angeles coordinates
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    println!("Question: {}\n", prompt);
+    println!("Response: {}", response.text());
+
+    // Display grounding sources if available
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("\n📍 Sources:");
+                for chunk in chunks {
+                    if let Some(maps) = &chunk.maps {
+                        println!("  • [{}]({})", maps.title, maps.uri);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 2: Specific place question with outdoor seating
+async fn place_specific_question(gemini: &Gemini) -> Result<(), Box<dyn std::error::Error>> {
+    println!("🪑 Example 2: Cafe with Outdoor Seating");
+
+    let prompt = "Is there a cafe near the corner of 1st and Main that has outdoor seating?";
+
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(None)) // No widget
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(34.050481, -118.248526)), // Los Angeles coordinates
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    println!("Question: {}\n", prompt);
+    println!("Response: {}", response.text());
+
+    // Display grounding sources if available
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("\n📍 Sources:");
+                for chunk in chunks {
+                    if let Some(maps) = &chunk.maps {
+                        println!("  • [{}]({})", maps.title, maps.uri);
+                        if let Some(place_id) = &maps.place_id {
+                            println!("    Place ID: {}", place_id);
+                        }
+                    }
+                }
+            }
+
+            // Display web search queries if available
+            if let Some(queries) = &grounding_metadata.web_search_queries {
+                println!("\n🔍 Search Queries:");
+                for query in queries {
+                    println!("  • {}", query);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 3: Family-friendly restaurants with playground reviews
+async fn family_friendly_recommendations(
+    gemini: &Gemini,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("👨‍👩‍👧‍👦 Example 3: Family-Friendly Restaurants with Playgrounds");
+
+    let prompt = "Which family-friendly restaurants near here have the best playground reviews?";
+
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(None)) // No widget
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(30.2672, -97.7431)), // Austin, TX coordinates
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    println!("Question: {}\n", prompt);
+    println!("Response: {}", response.text());
+
+    // Display grounding sources and supports
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("\n📍 Sources:");
+                for (i, chunk) in chunks.iter().enumerate() {
+                    if let Some(maps) = &chunk.maps {
+                        println!("  {}. [{}]({})", i + 1, maps.title, maps.uri);
+                    }
+                }
+            }
+
+            // Display grounding supports to see which parts of the response are grounded
+            if let Some(supports) = &grounding_metadata.grounding_supports {
+                println!("\n🔗 Grounded Segments:");
+                for support in supports {
+                    println!(
+                        "  • \"{}\" -> Sources: {:?}",
+                        support.segment.text, support.grounding_chunk_indices
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Example 4: Travel itinerary planning with widget support
+async fn travel_itinerary_planning(gemini: &Gemini) -> Result<(), Box<dyn std::error::Error>> {
+    println!("✈️  Example 4: San Francisco Day Trip Planning");
+
+    let prompt = "Plan a day in San Francisco for me. I want to see the Golden Gate Bridge, visit a museum, and have a nice dinner.";
+
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(Some(true))) // With widget enabled
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(37.78193, -122.40476)), // San Francisco coordinates
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    println!("Question: {}\n", prompt);
+    println!("Response: {}", response.text());
+
+    // Display comprehensive grounding information
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("\n📍 Sources:");
+                for (i, chunk) in chunks.iter().enumerate() {
+                    if let Some(maps) = &chunk.maps {
+                        println!("  {}. [{}]({})", i + 1, maps.title, maps.uri);
+                        if let Some(place_id) = &maps.place_id {
+                            println!("     Place ID: {}", place_id);
+                        }
+                    }
+                }
+            }
+
+            // Display widget context token if available
+            if let Some(widget_token) = &grounding_metadata.google_maps_widget_context_token {
+                println!("\n🗺️  Google Maps Widget Context Token:");
+                println!(
+                    "  <gmp-place-contextual context-token=\"{}\"></gmp-place-contextual>",
+                    widget_token
+                );
+                println!("  \nYou can use this token to render an interactive Google Maps widget in your web application.");
+            }
+
+            // Display grounding supports with text segments
+            if let Some(supports) = &grounding_metadata.grounding_supports {
+                println!("\n🔗 Detailed Grounding Information:");
+                for support in supports {
+                    let segment = &support.segment;
+                    println!("  • Text: \"{}\"", segment.text);
+                    println!(
+                        "    Location: chars {}-{}",
+                        segment.start_index, segment.end_index
+                    );
+                    println!("    Sources: {:?}", support.grounding_chunk_indices);
+                    println!();
+                }
+            }
+
+            // Display search queries
+            if let Some(queries) = &grounding_metadata.web_search_queries {
+                println!("🔍 Search Queries Used:");
+                for query in queries {
+                    println!("  • {}", query);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/simple_maps_example.rs
+++ b/examples/simple_maps_example.rs
@@ -1,0 +1,58 @@
+//! Simple Google Maps Grounding Example
+//!
+//! A minimal example showing how to use Google Maps grounding for location-aware queries.
+
+use gemini_rust::prelude::*;
+use gemini_rust::{LatLng, RetrievalConfig, Tool, ToolConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize the Gemini client with API key from environment
+    let gemini = Gemini::pro(std::env::var("GEMINI_API_KEY")?)?;
+
+    println!("🗺️  Simple Google Maps Grounding Example\n");
+
+    // Ask for restaurant recommendations with location context
+    let prompt = "What are the best coffee shops near me?";
+
+    println!("Query: {}", prompt);
+    println!("Location: San Francisco (37.7749, -122.4194)\n");
+
+    // Use Google Maps grounding with San Francisco coordinates
+    let response = gemini
+        .generate_content()
+        .with_user_message(prompt)
+        .with_tool(Tool::google_maps(None)) // No widget
+        .with_tool_config(ToolConfig {
+            retrieval_config: Some(RetrievalConfig {
+                lat_lng: Some(LatLng::new(37.7749, -122.4194)), // San Francisco
+            }),
+            function_calling_config: None,
+        })
+        .execute()
+        .await?;
+
+    // Display the response
+    println!("🤖 Response:");
+    println!("{}", response.text());
+
+    // Show grounding sources if available
+    if let Some(candidate) = response.candidates.first() {
+        if let Some(grounding_metadata) = &candidate.grounding_metadata {
+            if let Some(chunks) = &grounding_metadata.grounding_chunks {
+                println!("\n📍 Grounding Sources:");
+                for chunk in chunks {
+                    if let Some(maps) = &chunk.maps {
+                        println!("  • {} - {}", maps.title, maps.uri);
+                    }
+                }
+            } else {
+                println!("\nℹ️  No grounding sources available for this response.");
+            }
+        } else {
+            println!("\nℹ️  No grounding metadata available for this response.");
+        }
+    }
+
+    Ok(())
+}

--- a/src/generation/builder.rs
+++ b/src/generation/builder.rs
@@ -248,6 +248,12 @@ impl ContentBuilder {
         self
     }
 
+    /// Sets the tool configuration for the request.
+    pub fn with_tool_config(mut self, tool_config: ToolConfig) -> Self {
+        self.tool_config = Some(tool_config);
+        self
+    }
+
     /// Sets the thinking configuration for the request (Gemini 2.5 series only).
     pub fn with_thinking_config(mut self, thinking_config: ThinkingConfig) -> Self {
         self.generation_config

--- a/src/generation/model.rs
+++ b/src/generation/model.rs
@@ -1,3 +1,4 @@
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -80,6 +81,9 @@ pub struct Candidate {
     /// The citation metadata for the candidate
     #[serde(skip_serializing_if = "Option::is_none")]
     pub citation_metadata: Option<CitationMetadata>,
+    /// The grounding metadata for the candidate
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grounding_metadata: Option<GroundingMetadata>,
     /// The finish reason for the candidate
     #[serde(skip_serializing_if = "Option::is_none")]
     pub finish_reason: Option<FinishReason>,
@@ -123,6 +127,81 @@ pub struct PromptTokenDetails {
     pub modality: Modality,
     /// Token count for this modality
     pub token_count: i32,
+}
+
+/// Grounding metadata for responses that use grounding tools
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundingMetadata {
+    /// Grounding chunks containing source information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grounding_chunks: Option<Vec<GroundingChunk>>,
+    /// Grounding supports connecting response text to sources
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grounding_supports: Option<Vec<GroundingSupport>>,
+    /// Web search queries used for grounding
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web_search_queries: Option<Vec<String>>,
+    /// Google Maps widget context token
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub google_maps_widget_context_token: Option<String>,
+}
+
+/// A chunk of grounding information from a source
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundingChunk {
+    /// Maps-specific grounding information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maps: Option<MapsGroundingChunk>,
+    /// Web-specific grounding information
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub web: Option<WebGroundingChunk>,
+}
+
+/// Maps-specific grounding chunk information
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct MapsGroundingChunk {
+    /// The URI of the Maps source
+    pub uri: Url,
+    /// The title of the Maps source
+    pub title: String,
+    /// The place ID from Google Maps
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub place_id: Option<String>,
+}
+
+/// Web-specific grounding chunk information
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct WebGroundingChunk {
+    /// The URI of the web source
+    pub uri: Url,
+    /// The title of the web source
+    pub title: String,
+}
+
+/// Support information connecting response text to grounding sources
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundingSupport {
+    /// Segment of the response text
+    pub segment: GroundingSegment,
+    /// Indices of grounding chunks that support this segment
+    pub grounding_chunk_indices: Vec<u32>,
+}
+
+/// A segment of response text
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GroundingSegment {
+    /// Start index of the segment in the response text
+    pub start_index: u32,
+    /// End index of the segment in the response text
+    pub end_index: u32,
+    /// The text content of the segment
+    pub text: String,
 }
 
 /// Response from the Gemini API for content generation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,12 @@ pub use models::{Blob, Content, Message, Modality, Part, Role};
 pub use generation::{
     builder::ContentBuilder, model::BlockReason, model::Candidate, model::CitationMetadata,
     model::CitationSource, model::FinishReason, model::GenerateContentRequest,
-    model::GenerationConfig, model::GenerationResponse, model::MultiSpeakerVoiceConfig,
-    model::PrebuiltVoiceConfig, model::PromptFeedback, model::PromptTokenDetails,
-    model::SpeakerVoiceConfig, model::SpeechConfig, model::ThinkingConfig, model::UsageMetadata,
-    model::VoiceConfig,
+    model::GenerationConfig, model::GenerationResponse, model::GroundingChunk,
+    model::GroundingMetadata, model::GroundingSegment, model::GroundingSupport,
+    model::MapsGroundingChunk, model::MultiSpeakerVoiceConfig, model::PrebuiltVoiceConfig,
+    model::PromptFeedback, model::PromptTokenDetails, model::SpeakerVoiceConfig,
+    model::SpeechConfig, model::ThinkingConfig, model::UsageMetadata, model::VoiceConfig,
+    model::WebGroundingChunk,
 };
 
 // ========== Text Embeddings ==========
@@ -109,7 +111,7 @@ pub use safety::model::{
 
 pub use tools::model::{
     FunctionCall, FunctionCallingConfig, FunctionCallingMode, FunctionDeclaration,
-    FunctionResponse, Tool, ToolConfig,
+    FunctionResponse, GoogleMapsConfig, LatLng, RetrievalConfig, Tool, ToolConfig,
 };
 
 // ========== Batch Processing ==========

--- a/src/tools/model.rs
+++ b/src/tools/model.rs
@@ -20,6 +20,11 @@ pub enum Tool {
     URLContext {
         url_context: URLContextConfig,
     },
+    /// Google Maps grounding tool
+    GoogleMaps {
+        /// The Google Maps configuration
+        google_maps: GoogleMapsConfig,
+    },
 }
 
 /// Empty configuration for Google Search tool
@@ -29,6 +34,15 @@ pub struct GoogleSearchConfig {}
 /// Empty configuration for URL Context tool
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct URLContextConfig {}
+
+/// Configuration for Google Maps grounding tool
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GoogleMapsConfig {
+    /// Optional: Enable widget context token generation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enable_widget: Option<bool>,
+}
 
 impl Tool {
     /// Create a new tool with a single function declaration
@@ -56,6 +70,13 @@ impl Tool {
     pub fn url_context() -> Self {
         Self::URLContext {
             url_context: URLContextConfig {},
+        }
+    }
+
+    /// Create a new Google Maps grounding tool
+    pub fn google_maps(enable_widget: Option<bool>) -> Self {
+        Self::GoogleMaps {
+            google_maps: GoogleMapsConfig { enable_widget },
         }
     }
 }
@@ -277,6 +298,9 @@ pub struct ToolConfig {
     /// The function calling config
     #[serde(skip_serializing_if = "Option::is_none")]
     pub function_calling_config: Option<FunctionCallingConfig>,
+    /// The retrieval config for location-based tools like Google Maps
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retrieval_config: Option<RetrievalConfig>,
 }
 
 /// Configuration for function calling
@@ -296,4 +320,32 @@ pub enum FunctionCallingMode {
     Any,
     /// The model must not use function calling
     None,
+}
+
+/// Retrieval configuration for location-based tools
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RetrievalConfig {
+    /// Optional: Latitude and longitude for location context
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lat_lng: Option<LatLng>,
+}
+
+/// Geographic coordinates
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LatLng {
+    /// Latitude in degrees
+    pub latitude: f64,
+    /// Longitude in degrees
+    pub longitude: f64,
+}
+
+impl LatLng {
+    /// Create a new LatLng coordinate
+    pub fn new(latitude: f64, longitude: f64) -> Self {
+        Self {
+            latitude,
+            longitude,
+        }
+    }
 }


### PR DESCRIPTION
  🗺️ Add Google Maps Grounding Support

  Summary

  This PR adds comprehensive Google Maps grounding functionality to the gemini-rust library, enabling location-aware responses with Google Maps data integration and interactive
  widget support.

  🚀 Features Added

  - Google Maps Tool Integration: New GoogleMaps tool variant with configurable widget support
  - Location Context Support: RetrievalConfig and LatLng types for precise location context
  - Grounding Metadata: Complete support for response grounding with Maps sources, web chunks, and widget tokens
  - Interactive Widget Support: Context token generation for rendering Google Maps widgets
  - Comprehensive Examples: Three complete examples demonstrating all features

  📝 Changes Made

  Core Library Changes

  - Added Google Maps tool to Tool enum in src/tools/model.rs
  - Added configuration types: GoogleMapsConfig, RetrievalConfig, LatLng
  - Added grounding metadata types: GroundingMetadata, GroundingChunk, MapsGroundingChunk, etc.
  - Updated response structures in src/generation/model.rs to include grounding metadata
  - Added convenience method with_tool_config() to ContentBuilder
  - Updated exports in src/lib.rs for all new types