### PR TITLE
Add Document and other for modality

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -272,6 +272,8 @@ impl Message {
 pub enum Modality {
     /// Default value.
     ModalityUnspecified,
+    /// Indicates the model should return a (json) document.
+    Document,
     /// Indicates the model should return text.
     Text,
     /// Indicates the model should return images.
@@ -280,4 +282,6 @@ pub enum Modality {
     Audio,
     /// Indicates the model should return video.
     Video,
+    #[serde(untagged)]
+    Other(String),
 }


### PR DESCRIPTION
I think document comes when you specify a json schema for the response.

This also adds Other(String) to make it forward-compatible with any future enums.