### PR TITLE
feat: add seed field to GenerationConfig

### DIFF
--- a/src/generation/builder.rs
+++ b/src/generation/builder.rs
@@ -223,6 +223,14 @@ impl ContentBuilder {
         self
     }
 
+    /// Sets the seed for the request.
+    pub fn with_seed(mut self, seed: i32) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .seed = Some(seed);
+        self
+    }
+
     /// Sets the maximum number of output tokens for the request.
     pub fn with_max_output_tokens(mut self, max_output_tokens: i32) -> Self {
         self.generation_config

--- a/src/generation/model.rs
+++ b/src/generation/model.rs
@@ -585,6 +585,14 @@ pub struct GenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub top_k: Option<i32>,
 
+    /// Seed used in decoding.
+    ///
+    /// By default, the model uses a random value for each request if a seed is not provided.
+    /// Setting a specific seed, along with consistent values for other parameters like temperature, can make the model return the same response for repeated requests with the same input.
+    /// Identical outputs are not guaranteed across all runs, due to backend infrastructure variations, but it provides a "best effort" for reproducibility.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i32>,
+
     /// The maximum number of tokens to generate
     ///
     /// Limits the length of the generated content. One token is roughly 4 characters.


### PR DESCRIPTION
Adding seed parameter to GenerationConfig 


The seed parameter for AI on Google Search's Gemini API models accepts a 32-bit integer. The range is 0 to 4,294,967,295. This applies to image, video, and text generation on Vertex AI. 