### PR TITLE
Adds responseJsonSchema to generationConfig

### DIFF
--- a/examples/json_schema.rs
+++ b/examples/json_schema.rs
@@ -1,0 +1,211 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::{Content, FunctionCallingMode, FunctionDeclaration, Gemini, Message, Role, Tool};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::env;
+use std::process::ExitCode;
+use tracing::info;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct BookRecommendation {
+    title: String,
+    author: String,
+    year: u32,
+    genre: String,
+    rating: f32,
+    summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct SearchCriteria {
+    genre: String,
+    min_year: Option<u32>,
+    max_year: Option<u32>,
+    min_rating: Option<f32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct SearchResults {
+    books: Vec<BookRecommendation>,
+    total_count: u32,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key).expect("unable to create Gemini API client");
+
+    info!("=== Example 1: Using response_json_schema for structured output ===");
+
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "The title of the book"
+            },
+            "author": {
+                "type": "string",
+                "description": "The author's name"
+            },
+            "year": {
+                "type": "integer",
+                "description": "Publication year"
+            },
+            "genre": {
+                "type": "string",
+                "description": "The genre of the book"
+            },
+            "rating": {
+                "type": "number",
+                "description": "Rating from 1.0 to 5.0"
+            },
+            "summary": {
+                "type": "string",
+                "description": "A brief summary of the book"
+            }
+        },
+        "required": ["title", "author", "year", "genre", "rating", "summary"]
+    });
+
+    let response = client
+        .generate_content()
+        .with_system_prompt("You recommend books in strict JSON format.")
+        .with_user_message("Recommend a classic science fiction book.")
+        .with_response_mime_type("application/json")
+        .with_response_json_schema(schema)
+        .execute()
+        .await?;
+
+    info!(
+        response = response.text(),
+        "structured JSON response received"
+    );
+
+    let book: BookRecommendation = serde_json::from_str(&response.text())?;
+    info!(
+        title = book.title,
+        author = book.author,
+        year = book.year,
+        genre = book.genre,
+        rating = book.rating,
+        "parsed book recommendation"
+    );
+
+    info!(
+        "\n=== Example 2: Using parametersJsonSchema and responseJsonSchema for function tools ==="
+    );
+
+    let search_books = FunctionDeclaration::new(
+        "search_books",
+        "Search for books by genre and optional year and rating filters",
+        None,
+    )
+    .with_parameters_json_schema::<SearchCriteria>()
+    .with_response_json_schema::<SearchResults>();
+
+    let tool = Tool::with_functions(vec![search_books]);
+
+    let response = client
+        .generate_content()
+        .with_system_prompt(
+            "You help users find books. When asked about books, use the search_books function.",
+        )
+        .with_user_message(
+            "Find me some fantasy books published after 2010 with a rating above 4.0",
+        )
+        .with_tool(tool.clone())
+        .with_function_calling_mode(FunctionCallingMode::Any)
+        .execute()
+        .await?;
+
+    if let Some(function_call) = response.function_calls().first() {
+        info!(
+            function_name = function_call.name,
+            args = ?function_call.args,
+            "function call received"
+        );
+
+        let criteria: SearchCriteria = serde_json::from_value(function_call.args.clone())?;
+        info!(
+            genre = criteria.genre,
+            min_year = ?criteria.min_year,
+            max_year = ?criteria.max_year,
+            min_rating = ?criteria.min_rating,
+            "parsed search criteria"
+        );
+
+        let search_results = SearchResults {
+            books: vec![
+                BookRecommendation {
+                    title: "The Name of the Wind".to_string(),
+                    author: "Patrick Rothfuss".to_string(),
+                    year: 2007,
+                    genre: "Fantasy".to_string(),
+                    rating: 4.5,
+                    summary: "A legendary hero tells his life story.".to_string(),
+                },
+                BookRecommendation {
+                    title: "The Way of Kings".to_string(),
+                    author: "Brandon Sanderson".to_string(),
+                    year: 2010,
+                    genre: "Fantasy".to_string(),
+                    rating: 4.6,
+                    summary: "Epic fantasy in a world of storms and magic.".to_string(),
+                },
+            ],
+            total_count: 2,
+        };
+
+        let mut conversation = client.generate_content();
+
+        conversation = conversation
+            .with_system_prompt(
+                "You help users find books. When asked about books, use the search_books function.",
+            )
+            .with_user_message(
+                "Find me some fantasy books published after 2010 with a rating above 4.0",
+            );
+
+        let model_content = Content::function_call((*function_call).clone());
+        let model_message = Message {
+            content: model_content,
+            role: Role::Model,
+        };
+        conversation = conversation.with_message(model_message);
+
+        conversation = conversation.with_function_response("search_books", search_results)?;
+
+        let final_response = conversation.with_tool(tool).execute().await?;
+
+        info!(
+            response = final_response.text(),
+            "final response with book recommendations"
+        );
+    } else {
+        info!("no function calls in response");
+        info!(response = response.text(), "direct response received");
+    }
+
+    Ok(())
+}

--- a/src/generation/builder.rs
+++ b/src/generation/builder.rs
@@ -264,9 +264,19 @@ impl ContentBuilder {
     /// When used with a JSON MIME type, this schema will be used to validate the model's
     /// output.
     pub fn with_response_schema(mut self, schema: serde_json::Value) -> Self {
-        self.generation_config
-            .get_or_insert_with(Default::default)
-            .response_schema = Some(schema);
+        let config = self.generation_config.get_or_insert_with(Default::default);
+        config.response_schema = Some(schema);
+        config.response_json_schema = None;
+        self
+    }
+
+    /// Sets the response JSON schema for strict structured output.
+    ///
+    /// Prefer this over `with_response_schema` for modern Gemini models.
+    pub fn with_response_json_schema(mut self, schema: serde_json::Value) -> Self {
+        let config = self.generation_config.get_or_insert_with(Default::default);
+        config.response_json_schema = Some(schema);
+        config.response_schema = None;
         self
     }
 

--- a/src/generation/model.rs
+++ b/src/generation/model.rs
@@ -614,6 +614,12 @@ pub struct GenerationConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_schema: Option<serde_json::Value>,
 
+    /// The response JSON schema (strict mode).
+    ///
+    /// Prefer this field for modern Gemini models that support JSON Schema natively.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_json_schema: Option<serde_json::Value>,
+
     /// Response modalities (for TTS and other multimodal outputs)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub response_modalities: Option<Vec<String>>,

--- a/src/tools/model.rs
+++ b/src/tools/model.rs
@@ -216,11 +216,14 @@ where
         s.meta_schema = None;
     }));
 
-    let mut schema = schema_generator.into_root_schema_for::<Parameters>();
-
-    // Root schemas always include a title field, which we don't want or need
-    schema.remove("title");
-    schema.to_value()
+    let schema = schema_generator.into_root_schema_for::<Parameters>();
+    let mut value =
+        serde_json::to_value(&schema).expect("schema should serialize to JSON value");
+    if let Value::Object(map) = &mut value {
+        map.remove("title");
+        map.remove("components");
+    }
+    value
 }
 
 impl FunctionDeclaration {

--- a/src/tools/model.rs
+++ b/src/tools/model.rs
@@ -199,7 +199,10 @@ pub struct FunctionDeclaration {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) parameters: Option<Value>,
     /// `Optional` The parameters for the function in JSON Schema format.
-    #[serde(rename = "parametersJsonSchema", skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "parametersJsonSchema",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub(crate) parameters_json_schema: Option<Value>,
     /// `Optional` Describes the output from this function in JSON Schema format. Reflects the
     /// Open API 3.03 Response Object. The Schema defines the type used for the response value
@@ -223,8 +226,7 @@ where
     }));
 
     let schema = schema_generator.into_root_schema_for::<Parameters>();
-    let mut value =
-        serde_json::to_value(&schema).expect("schema should serialize to JSON value");
+    let mut value = serde_json::to_value(&schema).expect("schema should serialize to JSON value");
     if let Value::Object(map) = &mut value {
         map.remove("title");
         map.remove("components");
@@ -243,8 +245,7 @@ where
     }));
 
     let schema = schema_generator.into_root_schema_for::<Parameters>();
-    let mut value =
-        serde_json::to_value(&schema).expect("schema should serialize to JSON value");
+    let mut value = serde_json::to_value(&schema).expect("schema should serialize to JSON value");
     if let Value::Object(map) = &mut value {
         map.remove("title");
         map.remove("$schema");


### PR DESCRIPTION
Introduces a dedicated JSON schema field for strict structured model outputs. This schema type is preferred for modern Gemini models that natively support JSON Schema.

responseJsonSchema is preferred over responseSchema in certain scenarios. After testing I found that responseJsonSchema performs quite differently and so should be supported here. Additionally, in my tests _responseJsonSchema and responseJsonSchema performed the same and had the same limitations on schema keywords. 

The API returns a `response_schema must not be set when response_json_schema is set.` error when using both which is handled here.

The API docs state the following regarding responseJsonSchema: "Optional. An internal detail. Use `responseJsonSchema` rather than this field.". Which is nonsensical. I opted here to use without the underscore as both seemed to work in my tests but we could change this to map to _responseJsonSchema if we notice issues. _responseJsonSchema looks like a legacy/codegen artifact that also currently works. We could also add a fallback mechanism if desired but this provides the most basic support for the field.

