### PR TITLE
Fix function call thought-signature replay

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -193,11 +193,12 @@ impl Content {
     }
 
     /// Create a new content with a function call
-    pub fn function_call(function_call: super::tools::FunctionCall) -> Self {
+    pub fn function_call(mut function_call: super::tools::FunctionCall) -> Self {
+        let thought_signature = function_call.thought_signature.take();
         Self {
             parts: Some(vec![Part::FunctionCall {
                 function_call,
-                thought_signature: None,
+                thought_signature,
             }]),
             role: None,
         }
@@ -205,9 +206,10 @@ impl Content {
 
     /// Create a new content with a function call and thought signature
     pub fn function_call_with_thought(
-        function_call: super::tools::FunctionCall,
+        mut function_call: super::tools::FunctionCall,
         thought_signature: impl Into<String>,
     ) -> Self {
+        function_call.thought_signature = None;
         Self {
             parts: Some(vec![Part::FunctionCall {
                 function_call,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -121,6 +121,9 @@ fn test_function_call_with_thought_signature() {
     // Test serialization
     let serialized = serde_json::to_string(&function_call).unwrap();
     println!("Serialized FunctionCall: {serialized}");
+    let json: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(json["thought_signature"], "test_thought_signature");
+    assert!(json.get("thoughtSignature").is_none());
 
     // Test deserialization
     let deserialized: FunctionCall = serde_json::from_str(&serialized).unwrap();
@@ -191,6 +194,16 @@ fn test_multi_turn_content_structure() {
         }
         _ => panic!("Expected FunctionCall part"),
     }
+
+    let content_from_helper = Content::function_call(function_call);
+    let helper_json = serde_json::to_value(&content_from_helper).unwrap();
+    assert_eq!(helper_json["parts"][0]["thoughtSignature"], "sample_thought_signature");
+    assert!(helper_json["parts"][0]["functionCall"]
+        .get("thoughtSignature")
+        .is_none());
+    assert!(helper_json["parts"][0]["functionCall"]
+        .get("thought_signature")
+        .is_none());
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- move function-call thought signatures onto the outer `Part::FunctionCall` payload
- make `Content::function_call(...)` lift any inner `FunctionCall.thought_signature` to the outer part automatically
- keep the explicit `Content::function_call_with_thought(...)` helper emitting the provider-native payload shape
- add regression coverage for the outer-part serialization shape

## Why
Gemini expects thought signatures on the outer content part, not nested inside the inner `functionCall` object. Nested replay payloads are rejected with `Unknown name "thoughtSignature" at ... function_call`.

This change makes the high-level content constructors produce the correct request shape and preserves compatibility for callers that were already setting `FunctionCall.thought_signature` before wrapping it in `Content::function_call(...)`.

## Testing
- `cargo test thought_signature -- --nocapture`
- `cargo build`