### PR TITLE
Add Part::ToolCall and Part::ToolResponse for server-side tool invocations

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -79,6 +79,20 @@ pub enum Part {
         #[serde(rename = "functionResponse")]
         function_response: super::tools::FunctionResponse,
     },
+    /// Server-side tool call (built-in tools e.g. google_search via includeServerSideToolInvocations)
+    ToolCall {
+        #[serde(rename = "toolCall")]
+        tool_call: serde_json::Value,
+        #[serde(rename = "thoughtSignature", skip_serializing_if = "Option::is_none")]
+        thought_signature: Option<String>,
+    },
+    /// Server-side tool response (built-in tool results)
+    ToolResponse {
+        #[serde(rename = "toolResponse")]
+        tool_response: serde_json::Value,
+        #[serde(rename = "thoughtSignature", skip_serializing_if = "Option::is_none")]
+        thought_signature: Option<String>,
+    },
     /// File reference for previously uploaded files
     FileData {
         #[serde(rename = "fileData")]


### PR DESCRIPTION
## Problem
`generateContent`/`streamGenerateContent` responses that use server-side tool invocation — built-in tools (`google_search`, `url_context`) combined with function tools via `toolConfig.includeServerSideToolInvocations = true` — return `toolCall` and `toolResponse` content parts. The `Part` enum has no variants for these, so any such response fails to deserialize.

## Change
Adds `Part::ToolCall` and `Part::ToolResponse` so responses mixing built-in and function tools decode cleanly. No behavior change for existing parts.

## Test
Verified against live `streamGenerateContent` responses that combine `google_search` with a function tool.