### PR TITLE
model: add finish_reason method

### DIFF
--- a/src/generation/model.rs
+++ b/src/generation/model.rs
@@ -278,6 +278,13 @@ impl GenerationResponse {
             .unwrap_or_default()
     }
 
+    /// Get the finish reason of the first candidate
+    pub fn finish_reason(&self) -> Option<FinishReason> {
+        self.candidates
+            .first()
+            .and_then(|c| c.finish_reason.clone())
+    }
+
     /// Get function calls from the response
     pub fn function_calls(&self) -> Vec<&crate::tools::FunctionCall> {
         self.candidates


### PR DESCRIPTION
Convenience method in GenerationResponse "finish_reason" to return optional first candidate FinishReason