### PR TITLE
feat: add Interactions API with full implementation, examples, and de…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,57 @@ gemini-rust = "1.7.1"
 
 ## 🚀 Quick Start
 
+### Interactions API (Recommended)
+
+The Interactions API is the simplest and best way to use Gemini models and agents. It provides server-side state management, observable execution steps, background execution, and unified support for models and agents.
+
+```rust,no_run
+use gemini_rust::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("GEMINI_API_KEY")?;
+    let client = Gemini::new(api_key)?;
+
+    // Basic text generation
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-2.5-flash")
+        .with_text("Hello! What is AI?")
+        .execute()
+        .await?;
+
+    println!("{}", interaction.output_text());
+
+    // Multi-turn with server-side state
+    let interaction2 = client
+        .create_interaction()
+        .with_model("gemini-2.5-flash")
+        .with_text("Give me 3 examples")
+        .with_previous_interaction(interaction.id().unwrap())
+        .execute()
+        .await?;
+
+    println!("{}", interaction2.output_text());
+
+    Ok(())
+}
+```
+
+Key features:
+- **Server-side state** — `previous_interaction_id` for multi-turn conversations
+- **Background execution** — `.with_background()` + polling
+- **Managed agents** — Deep Research, Antigravity
+- **Observable steps** — thoughts, function calls, tool usage as typed steps
+- **SSE streaming** — step lifecycle events (start/delta/stop)
+- **Structured output** — JSON schema via `.with_json_schema()`
+
+See the `interaction_*.rs` examples for complete coverage of every feature.
+
+### Legacy generateContent API
+
+The original `generateContent` API is still available but deprecated. New code should use the Interactions API.
+
 ### Basic Content Generation
 
 Get started with simple text generation, system prompts, and conversations. See [`basic_generation.rs`](examples/basic_generation.rs) for complete examples including simple messages, system prompts, and multi-turn conversations.

--- a/examples/advanced.rs
+++ b/examples/advanced.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, FunctionCallingMode, FunctionDeclaration, Gemini, Part};
 use schemars::JsonSchema;

--- a/examples/advanced_maps_configuration.rs
+++ b/examples/advanced_maps_configuration.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Advanced Google Maps Configuration Example
 //!
 //! This example demonstrates advanced configuration options for Google Maps grounding,

--- a/examples/basic_generation.rs
+++ b/examples/basic_generation.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use std::env;

--- a/examples/basic_streaming.rs
+++ b/examples/basic_streaming.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use futures::TryStreamExt;
 use gemini_rust::Gemini;

--- a/examples/blob.rs
+++ b/examples/blob.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose, Engine as _};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};

--- a/examples/complex_function.rs
+++ b/examples/complex_function.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::{collections::VecDeque, env};
 
 use gemini_rust::{

--- a/examples/curl_equivalent.rs
+++ b/examples/curl_equivalent.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, Gemini, Part};
 use std::env;

--- a/examples/curl_google_search.rs
+++ b/examples/curl_google_search.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, Gemini, Part, Tool};
 use std::env;

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use std::process::ExitCode;
 
 use display_error_chain::DisplayErrorChain;

--- a/examples/file_input.rs
+++ b/examples/file_input.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Demonstrates using file handles in content generation requests.
 //!
 //! This example shows how to upload a file and reference it in a generation request

--- a/examples/gemini_3_all_thinking_levels.rs
+++ b/examples/gemini_3_all_thinking_levels.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use gemini_rust::{prelude::*, ThinkingLevel};
 
 #[tokio::main]

--- a/examples/gemini_3_code_execution.rs
+++ b/examples/gemini_3_code_execution.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use gemini_rust::{prelude::*, Part, ThinkingLevel};
 
 #[tokio::main]

--- a/examples/gemini_3_thinking_and_media.rs
+++ b/examples/gemini_3_thinking_and_media.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use gemini_rust::{prelude::*, ThinkingLevel};
 
 #[tokio::main]

--- a/examples/gemini_pro_example.rs
+++ b/examples/gemini_pro_example.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use std::env;

--- a/examples/generation_config.rs
+++ b/examples/generation_config.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig};
 use std::env;

--- a/examples/google_maps_grounding.rs
+++ b/examples/google_maps_grounding.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Google Maps Grounding Examples
 //!
 //! This example demonstrates how to use the Google Maps grounding functionality

--- a/examples/google_search.rs
+++ b/examples/google_search.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, Tool};
 use std::env;

--- a/examples/google_search_with_functions.rs
+++ b/examples/google_search_with_functions.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::tools::Behavior;
 use gemini_rust::{

--- a/examples/image_editing.rs
+++ b/examples/image_editing.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, Model};

--- a/examples/image_generation.rs
+++ b/examples/image_generation.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Model};

--- a/examples/interaction_advanced.rs
+++ b/examples/interaction_advanced.rs
@@ -1,0 +1,100 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use serde_json::json;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("advanced interaction example starting");
+
+    let calc_tool = InteractionTool::function(
+        "calculate",
+        "Perform a mathematical calculation",
+        json!({
+            "type": "object",
+            "properties": {
+                "operation": { "type": "string", "description": "The operation: add, subtract, multiply, divide" },
+                "a": { "type": "number" },
+                "b": { "type": "number" }
+            },
+            "required": ["operation", "a", "b"]
+        }),
+    );
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("What is 42 times 12?")
+        .with_system_instruction(
+            "You are a helpful math assistant. Use the calculate tool for arithmetic.",
+        )
+        .with_tool(calc_tool)
+        .with_temperature(0.7)
+        .with_max_output_tokens(1000)
+        .with_thinking_level(InteractionThinkingLevel::Low)
+        .with_thinking_summaries(ThinkingSummaries::Auto)
+        .with_stop_sequences(vec!["END".to_string()])
+        .execute()
+        .await?;
+
+    for step in &interaction.steps {
+        match step {
+            Step::Thought { summary, .. } => {
+                for content in summary {
+                    let ThoughtSummaryContent::Text { text } = content;
+                    info!(thought = text, "thought");
+                }
+            }
+            Step::FunctionCall {
+                name, arguments, ..
+            } => {
+                info!(function = name, args = %arguments, "function call");
+            }
+            Step::ModelOutput { content, .. } => {
+                for c in content {
+                    if let InteractionContent::Text { text, .. } = c {
+                        info!(output = text, "model output");
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(usage) = &interaction.usage {
+        info!(
+            input_tokens = usage.total_input_tokens,
+            output_tokens = usage.total_output_tokens,
+            thought_tokens = usage.total_thought_tokens,
+            total_tokens = usage.total_tokens,
+            "token usage"
+        );
+    }
+
+    info!("advanced interaction example completed");
+    Ok(())
+}

--- a/examples/interaction_antigravity.rs
+++ b/examples/interaction_antigravity.rs
@@ -1,0 +1,99 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use std::time::Duration;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("antigravity managed agent example starting");
+
+    let interaction1 = client
+        .create_interaction()
+        .with_agent("antigravity-preview-05-2026")
+        .with_text("Write a Python script that generates the first 20 Fibonacci numbers and saves them to fibonacci.txt. Then read the file and print its contents.")
+        .with_environment_id("remote")
+        .with_background()
+        .execute()
+        .await?;
+
+    let id1 = interaction1.id().expect("interaction should have an id");
+    let env_id = interaction1
+        .environment_id
+        .as_deref()
+        .expect("interaction should have an environment_id");
+
+    info!(
+        interaction_id = id1,
+        environment_id = env_id,
+        status = interaction1.status.as_ref(),
+        "first interaction started (provisioning sandbox)"
+    );
+
+    let handle1 = client.interaction(id1);
+    let result1 = handle1.poll_until_completed(Duration::from_secs(5)).await?;
+
+    info!(
+        status = result1.status.as_ref(),
+        "first interaction completed"
+    );
+    info!(response = result1.output_text(), "first response");
+
+    info!(
+        previous_interaction_id = id1,
+        environment_id = env_id,
+        "starting second interaction (reusing sandbox)"
+    );
+
+    let interaction2 = client
+        .create_interaction()
+        .with_agent("antigravity-preview-05-2026")
+        .with_text("Now plot the Fibonacci sequence as a line chart and save it as chart.png.")
+        .with_previous_interaction(id1)
+        .with_environment_id(env_id)
+        .with_background()
+        .execute()
+        .await?;
+
+    let id2 = interaction2.id().expect("interaction should have an id");
+    info!(
+        interaction_id = id2,
+        status = interaction2.status.as_ref(),
+        "second interaction started"
+    );
+
+    let handle2 = client.interaction(id2);
+    let result2 = handle2.poll_until_completed(Duration::from_secs(5)).await?;
+
+    info!(
+        status = result2.status.as_ref(),
+        "second interaction completed"
+    );
+    info!(response = result2.output_text(), "second response");
+
+    info!("antigravity managed agent example completed");
+    Ok(())
+}

--- a/examples/interaction_background.rs
+++ b/examples/interaction_background.rs
@@ -1,0 +1,62 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use std::time::Duration;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("background execution example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-3.5-flash")
+        .with_text("Write a detailed analysis of the impact of quantum computing on cryptography, covering current threats, post-quantum algorithms, and migration strategies.")
+        .with_background()
+        .execute()
+        .await?;
+
+    let id = interaction.id().expect("interaction should have an id");
+    info!(
+        interaction_id = id,
+        status = interaction.status.as_ref(),
+        "background interaction started"
+    );
+
+    let handle = client.interaction(id);
+    let result = handle.poll_until_completed(Duration::from_secs(5)).await?;
+
+    info!(status = result.status.as_ref(), "interaction completed");
+
+    info!(response = result.output_text(), "final response");
+
+    if let Some(usage) = &result.usage {
+        info!(total_tokens = usage.total_tokens, "token usage");
+    }
+
+    info!("background execution example completed");
+    Ok(())
+}

--- a/examples/interaction_basic.rs
+++ b/examples/interaction_basic.rs
@@ -1,0 +1,60 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("interaction basic example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Hello, how are you?")
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction.output_text(),
+        "simple response received"
+    );
+
+    let interaction2 = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_system_instruction("You are a helpful assistant specializing in Rust programming.")
+        .with_text("What makes Rust a good choice for systems programming?")
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction2.output_text(),
+        "response with system instruction received"
+    );
+
+    info!("interaction basic example completed");
+    Ok(())
+}

--- a/examples/interaction_code_execution.rs
+++ b/examples/interaction_code_execution.rs
@@ -1,0 +1,67 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("code execution interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Calculate the 50th Fibonacci number using Python. Show your work.")
+        .with_code_execution()
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "response");
+
+    for step in &interaction.steps {
+        match step {
+            Step::CodeExecutionCall { arguments, .. } => {
+                info!(
+                    language = ?arguments.language,
+                    code = arguments.code.as_deref().unwrap_or(""),
+                    "code execution call"
+                );
+            }
+            Step::CodeExecutionResult {
+                result, is_error, ..
+            } => {
+                info!(
+                    result = result,
+                    is_error = is_error.unwrap_or(false),
+                    "code execution result"
+                );
+            }
+            _ => {}
+        }
+    }
+
+    info!("code execution example completed");
+    Ok(())
+}

--- a/examples/interaction_custom_client.rs
+++ b/examples/interaction_custom_client.rs
@@ -1,0 +1,63 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::{GeminiBuilder, Model};
+use std::process::ExitCode;
+use tracing::info;
+use url::Url;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+
+    let client = GeminiBuilder::new(&api_key)
+        .with_model(Model::Custom("gemini-flash-latest".to_string()))
+        .build()?;
+
+    info!("custom client interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_text("Hello from a custom-configured client!")
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "response");
+
+    let base_url = Url::parse("https://generativelanguage.googleapis.com/v1beta/")?;
+    let client2 = GeminiBuilder::new(&api_key)
+        .with_model(Model::Custom("gemini-pro-latest".to_string()))
+        .with_base_url(base_url)
+        .build()?;
+
+    info!("using client with explicit base URL and pro model");
+
+    let interaction2 = client2
+        .create_interaction()
+        .with_text("Explain quantum entanglement in one sentence.")
+        .execute()
+        .await?;
+
+    info!(response = interaction2.output_text(), "pro response");
+
+    info!("custom client example completed");
+    Ok(())
+}

--- a/examples/interaction_deep_research.rs
+++ b/examples/interaction_deep_research.rs
@@ -1,0 +1,77 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use std::time::Duration;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("deep research agent example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_agent("deep-research-preview-04-2026")
+        .with_text("Research the current state of quantum computing: key milestones, major players, and future predictions for 2026-2030.")
+        .with_agent_config(AgentConfig::DeepResearch {
+            thinking_summaries: Some(ThinkingSummaries::Auto),
+            visualization: Some(Visualization::Auto),
+            collaborative_planning: Some(false),
+            enable_bigquery_tool: None,
+        })
+        .with_background()
+        .execute()
+        .await?;
+
+    let id = interaction.id().expect("interaction should have an id");
+    info!(
+        interaction_id = id,
+        status = interaction.status.as_ref(),
+        "deep research started (this may take several minutes)"
+    );
+
+    let handle = client.interaction(id);
+    let result = handle.poll_until_completed(Duration::from_secs(10)).await?;
+
+    info!(status = result.status.as_ref(), "deep research completed");
+
+    info!(response = result.output_text(), "research output");
+
+    let thoughts = result.thoughts();
+    if !thoughts.is_empty() {
+        info!("thought summaries");
+        for (i, thought) in thoughts.iter().enumerate() {
+            if let Step::Thought { summary, .. } = thought {
+                for content in summary {
+                    let ThoughtSummaryContent::Text { text } = content;
+                    info!(thought.number = i + 1, thought = text, "thought summary");
+                }
+            }
+        }
+    }
+
+    info!("deep research example completed");
+    Ok(())
+}

--- a/examples/interaction_error_handling.rs
+++ b/examples/interaction_error_handling.rs
@@ -1,0 +1,57 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+
+    match do_main(&api_key).await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let formatted = DisplayErrorChain::new(&e).to_string();
+            error!(error = formatted, "request failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main(api_key: &str) -> Result<(), ClientError> {
+    let client = Gemini::new(api_key)?;
+
+    info!("sending interaction request");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Hello!")
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "response received");
+
+    info!("attempting to get a non-existent interaction");
+
+    match client.get_interaction("invalid-id-12345").await {
+        Ok(_) => {
+            info!("unexpectedly succeeded");
+        }
+        Err(e) => {
+            let formatted = DisplayErrorChain::new(&e).to_string();
+            info!(error = formatted, "expected error for invalid ID");
+        }
+    }
+
+    info!("interaction error handling example completed");
+    Ok(())
+}

--- a/examples/interaction_file_search.rs
+++ b/examples/interaction_file_search.rs
@@ -1,0 +1,61 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("file search interaction example starting");
+    info!("note: set FILE_SEARCH_STORE env var or use default test store");
+
+    let store_name = std::env::var("FILE_SEARCH_STORE")
+        .unwrap_or_else(|_| "fileSearchStores/testmlbestpractices-ccpiz0vc7vix".to_string());
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Search for documents about machine learning best practices")
+        .with_file_search(vec![store_name])
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "file search response");
+
+    for step in &interaction.steps {
+        match step {
+            Step::FileSearchCall { .. } => {
+                info!("file search call initiated");
+            }
+            Step::FileSearchResult { .. } => {
+                info!("file search result received");
+            }
+            _ => {}
+        }
+    }
+
+    info!("file search example completed");
+    Ok(())
+}

--- a/examples/interaction_function_calling.rs
+++ b/examples/interaction_function_calling.rs
@@ -1,0 +1,119 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use serde_json::json;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("function calling example starting (stateful loop)");
+
+    let get_weather = InteractionTool::function(
+        "get_weather",
+        "Get the current weather for a location",
+        json!({
+            "type": "object",
+            "properties": {
+                "location": { "type": "string", "description": "The city name" }
+            },
+            "required": ["location"]
+        }),
+    );
+
+    let mut previous_id: Option<String> = None;
+    let mut user_input = InteractionInput::text("What's the weather like in Tokyo?");
+
+    loop {
+        let mut builder = client
+            .create_interaction()
+            .with_model("gemini-flash-latest")
+            .with_tool(get_weather.clone());
+
+        if let Some(ref prev_id) = previous_id {
+            builder = builder.with_previous_interaction(prev_id);
+        }
+
+        builder = match user_input {
+            InteractionInput::Text(ref t) => builder.with_text(t.clone()),
+            InteractionInput::StepArray(ref steps) => builder.with_step_input(steps.clone()),
+            _ => builder,
+        };
+
+        let interaction = builder.execute().await?;
+
+        let function_calls: Vec<_> = interaction
+            .steps
+            .iter()
+            .filter_map(|s| {
+                if let Step::FunctionCall {
+                    name,
+                    arguments,
+                    id,
+                } = s
+                {
+                    Some((name.clone(), arguments.clone(), id.clone()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if function_calls.is_empty() {
+            info!(response = interaction.output_text(), "final response");
+            break;
+        }
+
+        let mut results = Vec::new();
+        for (name, args, call_id) in function_calls {
+            info!(function_name = name, args = %args, "function call received");
+
+            let location = args
+                .get("location")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+
+            let weather_result = json!({
+                "temperature": 22,
+                "unit": "celsius",
+                "condition": "sunny",
+                "location": location
+            });
+
+            results.push(Step::FunctionResult {
+                name: Some(name),
+                call_id,
+                result: StepResult::from_json(weather_result),
+                is_error: None,
+            });
+        }
+
+        previous_id = interaction.id().map(|s| s.to_string());
+        user_input = InteractionInput::step_array(results);
+    }
+
+    info!("function calling example completed");
+    Ok(())
+}

--- a/examples/interaction_google_maps.rs
+++ b/examples/interaction_google_maps.rs
@@ -1,0 +1,61 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("google maps interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Find me coffee shops near Times Square, New York")
+        .with_google_maps()
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "google maps response");
+
+    for step in &interaction.steps {
+        match step {
+            Step::GoogleMapsCall { arguments, .. } => {
+                info!(queries = ?arguments, "google maps call");
+            }
+            Step::GoogleMapsResult { result, .. } => {
+                if let Some(places) = &result.places {
+                    if let Some(ref p) = places.place_id {
+                        info!(place_id = p, "found place");
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    info!("google maps example completed");
+    Ok(())
+}

--- a/examples/interaction_google_search.rs
+++ b/examples/interaction_google_search.rs
@@ -1,0 +1,79 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("google search interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("What is the current Google stock price?")
+        .with_google_search()
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction.output_text(),
+        "google search response"
+    );
+
+    let citations = interaction.citations();
+    if !citations.is_empty() {
+        info!("citations found");
+        for (i, citation) in citations.iter().enumerate() {
+            match citation {
+                Annotation::UrlCitation {
+                    url,
+                    title,
+                    start_index,
+                    end_index,
+                    ..
+                } => {
+                    info!(
+                        citation.number = i + 1,
+                        url = url.as_deref().unwrap_or(""),
+                        title = title.as_deref().unwrap_or(""),
+                        start = start_index,
+                        end = end_index,
+                        "URL citation"
+                    );
+                }
+                Annotation::FileCitation { .. } => {
+                    info!(citation.number = i + 1, "file citation");
+                }
+                Annotation::PlaceCitation { .. } => {
+                    info!(citation.number = i + 1, "place citation");
+                }
+            }
+        }
+    }
+
+    info!("google search example completed");
+    Ok(())
+}

--- a/examples/interaction_image_gen.rs
+++ b/examples/interaction_image_gen.rs
@@ -1,0 +1,69 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::fs;
+use std::process::ExitCode;
+use tracing::{info, warn};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("image generation interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-3.1-flash-image")
+        .with_text("Create a picture of a nano banana dish in a fancy restaurant with a Gemini theme. Photorealistic with elegant lighting.")
+        .with_temperature(1.0)
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "text response");
+
+    if let Some(InteractionContent::Image {
+        data, mime_type, ..
+    }) = interaction.output_image()
+    {
+        if let Some(ref image_data) = data {
+            match BASE64.decode(image_data) {
+                Ok(image_bytes) => {
+                    let ext = match mime_type {
+                        Some(ImageMimeType::Jpeg) => "jpg",
+                        _ => "png",
+                    };
+                    let filename = format!("generated_interaction_image.{ext}");
+                    fs::write(&filename, image_bytes)?;
+                    info!(filename = filename, "image saved successfully");
+                }
+                Err(e) => {
+                    warn!(error = ?e, "failed to decode image data");
+                }
+            }
+        }
+    }
+
+    info!("image generation example completed");
+    Ok(())
+}

--- a/examples/interaction_multi_turn.rs
+++ b/examples/interaction_multi_turn.rs
@@ -1,0 +1,99 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("multi-turn conversation example (stateful)");
+
+    let interaction1 = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("I have 2 dogs in my house.")
+        .execute()
+        .await?;
+
+    info!(response = interaction1.output_text(), "response 1");
+
+    let id1 = interaction1.id().expect("interaction should have an id");
+
+    let interaction2 = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("How many paws are in my house?")
+        .with_previous_interaction(id1)
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction2.output_text(),
+        "response 2 (uses server-side state)"
+    );
+
+    info!("multi-turn conversation example (stateless)");
+
+    let history = vec![Step::UserInput {
+        content: vec![InteractionContent::text("I have 2 dogs in my house.")],
+    }];
+
+    let interaction3 = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_store(false)
+        .with_step_input(history.clone())
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction3.output_text(),
+        "response 3a (stateless)"
+    );
+
+    let mut history2 = history;
+    for step in &interaction3.steps {
+        history2.push(step.clone());
+    }
+    history2.push(Step::UserInput {
+        content: vec![InteractionContent::text("How many paws are in my house?")],
+    });
+
+    let interaction4 = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_store(false)
+        .with_step_input(history2)
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction4.output_text(),
+        "response 4 (stateless, client-side history)"
+    );
+
+    info!("multi-turn example completed");
+    Ok(())
+}

--- a/examples/interaction_multimodal.rs
+++ b/examples/interaction_multimodal.rs
@@ -1,0 +1,62 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::fs;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("multimodal interaction example starting");
+
+    let image_data = fs::read("examples/image-example.webp")?;
+    let image_b64 = BASE64.encode(&image_data);
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("What's in this image?")
+        .with_image(image_b64, ImageMimeType::Webp)
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "image analysis");
+
+    info!("multimodal example with video URI");
+
+    let video_interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Describe this video in detail.")
+        .with_video("https://storage.googleapis.com/generativeai-downloads/images/GreatRedSpot.mp4")
+        .execute()
+        .await?;
+
+    info!(response = video_interaction.output_text(), "video analysis");
+
+    info!("multimodal example completed");
+    Ok(())
+}

--- a/examples/interaction_streaming.rs
+++ b/examples/interaction_streaming.rs
@@ -1,0 +1,86 @@
+use display_error_chain::DisplayErrorChain;
+use futures::TryStreamExt;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("interaction streaming example starting");
+
+    let mut stream = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text(
+            "Tell me a short story about a programmer who discovers a magical bug in their code",
+        )
+        .execute_stream()
+        .await?;
+
+    let mut full_response = String::new();
+    while let Some(event) = stream.try_next().await? {
+        match event {
+            InteractionEvent::StepStart { index, step, .. } => {
+                info!(
+                    step.index = index,
+                    step.type_ = std::format!("{:?}", step),
+                    "step started"
+                );
+            }
+            InteractionEvent::StepDelta { index, delta, .. } => {
+                if let StepDeltaData::Text { text } = delta {
+                    info!(step.index = index, text = %text, "delta");
+                    full_response.push_str(&text);
+                }
+            }
+            InteractionEvent::StepStop { index, usage, .. } => {
+                info!(step.index = index, "step completed");
+                if let Some(u) = usage {
+                    info!(
+                        step.index = index,
+                        total_tokens = u.total_tokens,
+                        "step usage"
+                    );
+                }
+            }
+            InteractionEvent::InteractionCompleted { interaction, .. } => {
+                info!(
+                    status = interaction.status.as_ref(),
+                    "interaction completed"
+                );
+            }
+            _ => {}
+        }
+    }
+
+    info!(
+        response_length = full_response.len(),
+        "streaming response completed"
+    );
+
+    info!("interaction streaming example completed");
+    Ok(())
+}

--- a/examples/interaction_structured.rs
+++ b/examples/interaction_structured.rs
@@ -1,0 +1,60 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use serde_json::json;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("structured output example starting");
+
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "recipe_name": { "type": "string" },
+            "ingredients": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "prep_time_minutes": { "type": "integer" }
+        },
+        "required": ["recipe_name", "ingredients"]
+    });
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Give me a recipe for banana bread")
+        .with_json_schema(schema)
+        .execute()
+        .await?;
+
+    let recipe: serde_json::Value = serde_json::from_str(&interaction.output_text())?;
+    info!(recipe = %recipe, "parsed JSON recipe");
+
+    info!("structured output example completed");
+    Ok(())
+}

--- a/examples/interaction_thinking.rs
+++ b/examples/interaction_thinking.rs
@@ -1,0 +1,86 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("thinking levels example starting");
+
+    for level in [
+        InteractionThinkingLevel::Low,
+        InteractionThinkingLevel::High,
+    ] {
+        info!(thinking.level = ?level, "sending request");
+
+        let interaction = client
+            .create_interaction()
+            .with_model("gemini-flash-latest")
+            .with_text("Explain Occam's razor and give a simple example")
+            .with_thinking_level(level.clone())
+            .with_thinking_summaries(ThinkingSummaries::Auto)
+            .execute()
+            .await?;
+
+        let thoughts: Vec<String> = interaction
+            .thoughts()
+            .iter()
+            .filter_map(|s| {
+                if let Step::Thought { summary, .. } = s {
+                    let texts: Vec<String> = summary
+                        .iter()
+                        .map(|c| {
+                            let ThoughtSummaryContent::Text { text } = c;
+                            text.clone()
+                        })
+                        .collect();
+                    Some(texts)
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect();
+
+        for (i, thought) in thoughts.iter().enumerate() {
+            info!(thinking.level = ?level, thought.number = i + 1, thought = thought, "thought");
+        }
+
+        info!(thinking.level = ?level, answer = interaction.output_text(), "answer");
+
+        if let Some(usage) = &interaction.usage {
+            info!(
+                thinking.level = ?level,
+                thought_tokens = usage.total_thought_tokens,
+                total_tokens = usage.total_tokens,
+                "token usage"
+            );
+        }
+    }
+
+    info!("thinking levels example completed");
+    Ok(())
+}

--- a/examples/interaction_tracing.rs
+++ b/examples/interaction_tracing.rs
@@ -1,0 +1,59 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("tracing interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("What is the capital of France?")
+        .with_system_instruction("You are a concise geography expert.")
+        .with_temperature(0.3)
+        .execute()
+        .await?;
+
+    info!(
+        response = interaction.output_text(),
+        status = interaction.status.as_ref(),
+        "interaction completed"
+    );
+
+    if let Some(usage) = &interaction.usage {
+        info!(
+            total_tokens = usage.total_tokens,
+            input_tokens = usage.total_input_tokens,
+            output_tokens = usage.total_output_tokens,
+            "usage details"
+        );
+    }
+
+    info!("tracing example completed — check the tracing output above for structured spans");
+    Ok(())
+}

--- a/examples/interaction_tts.rs
+++ b/examples/interaction_tts.rs
@@ -1,0 +1,68 @@
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::fs;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("text-to-speech interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-3.1-flash-tts-preview")
+        .with_text("Say hello in a cheerful voice: 'Hello! Welcome to the world of AI!'")
+        .with_speech_config(InteractionSpeechConfig {
+            voice: Some("Charon".to_string()),
+            language: None,
+            speaker: None,
+        })
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "text response");
+
+    if let Some(InteractionContent::Audio {
+        data, mime_type, ..
+    }) = interaction.output_audio()
+    {
+        if let Some(ref audio_data) = data {
+            let audio_bytes = BASE64.decode(audio_data)?;
+            let ext = match mime_type {
+                Some(AudioMimeType::Mp3) => "mp3",
+                Some(AudioMimeType::Wav) => "wav",
+                _ => "pcm",
+            };
+            let filename = format!("generated_speech.{ext}");
+            fs::write(&filename, audio_bytes)?;
+            info!(filename = filename, "audio saved");
+        }
+    }
+
+    info!("text-to-speech example completed");
+    Ok(())
+}

--- a/examples/interaction_url_context.rs
+++ b/examples/interaction_url_context.rs
@@ -1,0 +1,59 @@
+use display_error_chain::DisplayErrorChain;
+use gemini_rust::prelude::*;
+use std::process::ExitCode;
+use tracing::info;
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    match do_main().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            let error_chain = DisplayErrorChain::new(e.as_ref());
+            tracing::error!(error.debug = ?e, error.chained = %error_chain, "execution failed");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn do_main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("GEMINI_API_KEY").expect("GEMINI_API_KEY environment variable not set");
+    let client = Gemini::new(api_key)?;
+
+    info!("url context interaction example starting");
+
+    let interaction = client
+        .create_interaction()
+        .with_model("gemini-flash-latest")
+        .with_text("Summarize the main points from this article: https://en.wikipedia.org/wiki/Rust_(programming_language)")
+        .with_url_context()
+        .execute()
+        .await?;
+
+    info!(response = interaction.output_text(), "url context response");
+
+    for step in &interaction.steps {
+        if let Step::UrlContextResult {
+            result, is_error, ..
+        } = step
+        {
+            info!(
+                url = result.url.as_deref().unwrap_or(""),
+                status = ?result.status,
+                is_error = is_error.unwrap_or(false),
+                "url context result"
+            );
+        }
+    }
+
+    info!("url context example completed");
+    Ok(())
+}

--- a/examples/json_schema.rs
+++ b/examples/json_schema.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, FunctionCallingMode, FunctionDeclaration, Gemini, Message, Role, Tool};
 use schemars::JsonSchema;

--- a/examples/mp4_describe.rs
+++ b/examples/mp4_describe.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 // Please put your sample video at examples/sample.mp4
 // This example sends the mp4 video content to Gemini API and asks AI to describe the video.
 

--- a/examples/multi_speaker_tts.rs
+++ b/examples/multi_speaker_tts.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose, Engine as _};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Part, SpeakerVoiceConfig, SpeechConfig};

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{
     Content, FunctionCallingMode, FunctionDeclaration, Gemini, GenerationConfig, Message, Role,

--- a/examples/simple_image_generation.rs
+++ b/examples/simple_image_generation.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Model};

--- a/examples/simple_maps_example.rs
+++ b/examples/simple_maps_example.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 //! Simple Google Maps Grounding Example
 //!
 //! A minimal example showing how to use Google Maps grounding for location-aware queries.

--- a/examples/simple_speech_generation.rs
+++ b/examples/simple_speech_generation.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose, Engine as _};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Part, PrebuiltVoiceConfig, SpeechConfig, VoiceConfig};

--- a/examples/simple_thought_signature.rs
+++ b/examples/simple_thought_signature.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{FunctionCallingMode, FunctionDeclaration, Gemini, ThinkingConfig, Tool};
 use schemars::JsonSchema;

--- a/examples/streaming.rs
+++ b/examples/streaming.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use futures_util::TryStreamExt;
 use gemini_rust::Gemini;

--- a/examples/structured_response.rs
+++ b/examples/structured_response.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::Gemini;
 use serde_json::json;

--- a/examples/text_thought_signature_example.rs
+++ b/examples/text_thought_signature_example.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 /// Example demonstrating text responses with thoughtSignature support
 ///
 /// This example shows how to handle text responses that include thought signatures,

--- a/examples/thinking_advanced.rs
+++ b/examples/thinking_advanced.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use futures::TryStreamExt;
 use gemini_rust::{FunctionDeclaration, Gemini, ThinkingConfig};

--- a/examples/thinking_banana.rs
+++ b/examples/thinking_banana.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, Part};

--- a/examples/thinking_basic.rs
+++ b/examples/thinking_basic.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, ThinkingConfig};
 use std::env;

--- a/examples/thinking_curl_equivalent.rs
+++ b/examples/thinking_curl_equivalent.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Gemini, GenerationConfig, ThinkingConfig};
 use std::env;

--- a/examples/thought_signature_example.rs
+++ b/examples/thought_signature_example.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 /// Comprehensive example demonstrating thoughtSignature support in Gemini 2.5 Pro
 ///

--- a/examples/tools.rs
+++ b/examples/tools.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use display_error_chain::DisplayErrorChain;
 use gemini_rust::{Content, FunctionCallingMode, FunctionDeclaration, Gemini, Message, Role, Tool};
 use schemars::JsonSchema;

--- a/examples/url_context.rs
+++ b/examples/url_context.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 /*!
 # URL Context Tool Example
 

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use snafu::Snafu;
 
 pub mod builder;

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,3 +1,4 @@
+#[allow(deprecated)]
 use crate::{
     batch::{BatchBuilder, BatchHandle},
     cache::{CacheBuilder, CachedContentHandle},
@@ -10,6 +11,12 @@ use crate::{
         model::{File, ListFilesResponse},
     },
     generation::{ContentBuilder, GenerateContentRequest, GenerationResponse},
+    interactions::{
+        builder::InteractionBuilder,
+        handle::InteractionHandle,
+        model::{CreateInteractionRequest, Interaction},
+        stream::{InteractionEvent, InteractionStream},
+    },
 };
 use eventsource_stream::{EventStreamError, Eventsource};
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -37,6 +44,7 @@ use crate::cache::model::*;
 /// A pinned, boxed stream that yields `GenerationResponse` chunks as they arrive
 /// from the API. Used for streaming content generation to receive partial results
 /// before the complete response is ready.
+#[allow(deprecated)]
 pub type GenerationStream = Pin<Box<dyn Stream<Item = Result<GenerationResponse, Error>> + Send>>;
 
 static DEFAULT_BASE_URL: LazyLock<Url> = LazyLock::new(|| {
@@ -362,6 +370,7 @@ impl GeminiClient {
     }
 
     /// Generate content
+    #[allow(deprecated)]
     #[instrument(skip_all, fields(
         model,
         messages.parts.count = request.contents.len(),
@@ -398,6 +407,7 @@ impl GeminiClient {
     }
 
     /// Generate content with streaming
+    #[allow(deprecated)]
     #[instrument(skip_all, fields(
         model,
         messages.parts.count = request.contents.len(),
@@ -423,6 +433,7 @@ impl GeminiClient {
             stream
                 .eventsource()
                 .map(|event| event.context(BadPartSnafu))
+                .try_filter(|event| std::future::ready(event.data != "[DONE]"))
                 .and_then(|event| async move {
                     serde_json::from_str::<GenerationResponse>(&event.data)
                         .context(DeserializeSnafu)
@@ -431,6 +442,7 @@ impl GeminiClient {
     }
 
     /// Count tokens for content
+    #[allow(deprecated)]
     #[instrument(skip_all, fields(
         model,
         messages.parts.count = request.contents.len(),
@@ -765,6 +777,128 @@ impl GeminiClient {
         }
 
         self.get_json(url).await
+    }
+
+    // ========== Interactions API ==========
+
+    /// Create an interaction (non-streaming).
+    #[instrument(skip_all, fields(
+        model = request.model.as_deref().unwrap_or(""),
+        agent = request.agent.as_deref().unwrap_or(""),
+        tools.count = request.tools.len(),
+        background = request.background.unwrap_or(false),
+        previous.interaction.present = request.previous_interaction_id.is_some(),
+        status.code,
+        usage.total_tokens,
+    ))]
+    pub(crate) async fn create_interaction(
+        &self,
+        request: CreateInteractionRequest,
+    ) -> Result<Interaction, Error> {
+        let url = self.build_url_with_suffix("interactions")?;
+        let response: Interaction = self.post_json(url, &request).await?;
+
+        Span::current().record("status.code", response.status.as_ref());
+
+        if let Some(usage) = &response.usage {
+            Span::current().record("usage.total_tokens", usage.total_tokens);
+        }
+
+        Ok(response)
+    }
+
+    /// Create an interaction (streaming).
+    #[instrument(skip_all, fields(
+        model = request.model.as_deref().unwrap_or(""),
+        agent = request.agent.as_deref().unwrap_or(""),
+        tools.count = request.tools.len(),
+    ))]
+    pub(crate) async fn create_interaction_stream(
+        &self,
+        mut request: CreateInteractionRequest,
+    ) -> Result<InteractionStream, Error> {
+        let mut url = self.build_url_with_suffix("interactions")?;
+        url.query_pairs_mut().append_pair("alt", "sse");
+        request.stream = Some(true);
+
+        let stream = self
+            .perform_request(
+                |c| c.post(url).json(&request),
+                async |r| Ok(r.bytes_stream()),
+            )
+            .await?;
+
+        Ok(Box::pin(
+            stream
+                .eventsource()
+                .map(|event| event.context(BadPartSnafu))
+                .try_filter(|event| std::future::ready(event.data != "[DONE]"))
+                .and_then(|event| async move {
+                    serde_json::from_str::<InteractionEvent>(&event.data).context(DeserializeSnafu)
+                }),
+        ))
+    }
+
+    /// Get an interaction by ID.
+    #[instrument(skip_all, fields(
+        interaction.id = id,
+    ))]
+    pub(crate) async fn get_interaction(&self, id: &str) -> Result<Interaction, Error> {
+        let url = self.build_url_with_suffix(&format!("interactions/{id}"))?;
+        self.get_json(url).await
+    }
+
+    /// Get an interaction in streaming mode (resume from last_event_id).
+    #[instrument(skip_all, fields(
+        interaction.id = id,
+    ))]
+    pub(crate) async fn get_interaction_stream(
+        &self,
+        id: &str,
+        last_event_id: Option<&str>,
+    ) -> Result<InteractionStream, Error> {
+        let mut url = self.build_url_with_suffix(&format!("interactions/{id}"))?;
+        url.query_pairs_mut().append_pair("stream", "true");
+        if let Some(event_id) = last_event_id {
+            url.query_pairs_mut().append_pair("last_event_id", event_id);
+        }
+
+        let stream = self
+            .perform_request(|c| c.get(url), async |r| Ok(r.bytes_stream()))
+            .await?;
+
+        Ok(Box::pin(
+            stream
+                .eventsource()
+                .map(|event| event.context(BadPartSnafu))
+                .try_filter(|event| std::future::ready(event.data != "[DONE]"))
+                .and_then(|event| async move {
+                    serde_json::from_str::<InteractionEvent>(&event.data).context(DeserializeSnafu)
+                }),
+        ))
+    }
+
+    /// Cancel an interaction.
+    #[instrument(skip_all, fields(
+        interaction.id = id,
+    ))]
+    pub(crate) async fn cancel_interaction(&self, id: &str) -> Result<Interaction, Error> {
+        let url = self.build_url_with_suffix(&format!("interactions/{id}/cancel"))?;
+        self.perform_request(
+            |c| c.post(url).json(&json!({})),
+            async |r| r.json().await.context(DecodeResponseSnafu),
+        )
+        .await
+    }
+
+    /// Delete an interaction.
+    #[instrument(skip_all, fields(
+        interaction.id = id,
+    ))]
+    pub(crate) async fn delete_interaction(&self, id: &str) -> Result<(), Error> {
+        let url = self.build_url_with_suffix(&format!("interactions/{id}"))?;
+        self.perform_request(|c| c.delete(url), async |_r| Ok(()))
+            .await
     }
 
     /// Build a URL with the given suffix
@@ -1187,8 +1321,34 @@ impl Gemini {
     }
 
     /// Start building a content generation request
+    #[deprecated(
+        since = "1.8.0",
+        note = "Use Gemini::create_interaction() instead. See migration guide: interactions-api/migration-plan.md"
+    )]
+    #[allow(deprecated)]
     pub fn generate_content(&self) -> ContentBuilder {
         ContentBuilder::new(self.client.clone())
+    }
+
+    /// Start building an interaction request.
+    ///
+    /// The Interactions API is the recommended way to use Gemini models and agents.
+    /// It provides server-side state management, observable steps, background execution,
+    /// and unified support for models and agents.
+    pub fn create_interaction(&self) -> InteractionBuilder {
+        InteractionBuilder::new(self.client.clone())
+    }
+
+    /// Get a handle to an interaction by its ID.
+    ///
+    /// The handle can be used for get, cancel, delete, and poll operations.
+    pub fn interaction(&self, id: &str) -> InteractionHandle {
+        InteractionHandle::new(id.to_string(), self.client.clone())
+    }
+
+    /// Get the full interaction resource by ID.
+    pub async fn get_interaction(&self, id: &str) -> Result<Interaction, Error> {
+        self.client.get_interaction(id).await
     }
 
     /// Start building a content embedding request

--- a/src/generation/builder.rs
+++ b/src/generation/builder.rs
@@ -15,6 +15,10 @@ use crate::{
 };
 
 /// Builder for content generation requests
+#[deprecated(
+    since = "1.8.0",
+    note = "Use crate::interactions::InteractionBuilder instead. See migration guide: interactions-api/migration-plan.md"
+)]
 #[derive(Clone)]
 pub struct ContentBuilder {
     client: Arc<GeminiClient>,

--- a/src/generation/mod.rs
+++ b/src/generation/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 pub mod builder;
 pub mod model;
 

--- a/src/generation/model.rs
+++ b/src/generation/model.rs
@@ -208,6 +208,10 @@ pub struct GroundingSegment {
 }
 
 /// Response from the Gemini API for content generation
+#[deprecated(
+    since = "1.8.0",
+    note = "Use crate::interactions::Interaction instead. See migration guide: interactions-api/migration-plan.md"
+)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerationResponse {
@@ -414,6 +418,10 @@ impl GenerationResponse {
 }
 
 /// Request to generate content
+#[deprecated(
+    since = "1.8.0",
+    note = "Use crate::interactions::CreateInteractionRequest instead. See migration guide: interactions-api/migration-plan.md"
+)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerateContentRequest {
@@ -567,6 +575,10 @@ impl Default for ThinkingConfig {
 }
 
 /// Configuration for generation
+#[deprecated(
+    since = "1.8.0",
+    note = "Use crate::interactions::InteractionGenerationConfig instead"
+)]
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerationConfig {

--- a/src/interactions/builder.rs
+++ b/src/interactions/builder.rs
@@ -1,0 +1,490 @@
+use std::sync::Arc;
+use tracing::{instrument, Span};
+
+use crate::client::{Error as ClientError, GeminiClient};
+use crate::interactions::model::*;
+use crate::interactions::stream::InteractionStream;
+
+/// Fluent builder for constructing and executing interaction requests.
+#[derive(Clone)]
+pub struct InteractionBuilder {
+    client: Arc<GeminiClient>,
+    model: Option<String>,
+    agent: Option<String>,
+    input: Option<InteractionInput>,
+    system_instruction: Option<String>,
+    tools: Vec<InteractionTool>,
+    response_format: Option<ResponseFormat>,
+    store: Option<bool>,
+    background: bool,
+    generation_config: Option<InteractionGenerationConfig>,
+    agent_config: Option<AgentConfig>,
+    previous_interaction_id: Option<String>,
+    environment: Option<EnvironmentConfigOrString>,
+    cached_content: Option<String>,
+    response_modalities: Vec<ResponseModality>,
+    service_tier: Option<ServiceTier>,
+    webhook_config: Option<WebhookConfig>,
+}
+
+impl InteractionBuilder {
+    pub(crate) fn new(client: Arc<GeminiClient>) -> Self {
+        Self {
+            client,
+            model: None,
+            agent: None,
+            input: None,
+            system_instruction: None,
+            tools: Vec::new(),
+            response_format: None,
+            store: None,
+            background: false,
+            generation_config: None,
+            agent_config: None,
+            previous_interaction_id: None,
+            environment: None,
+            cached_content: None,
+            response_modalities: Vec::new(),
+            service_tier: None,
+            webhook_config: None,
+        }
+    }
+
+    // ===== Model / Agent =====
+
+    /// Set the model (mutually exclusive with agent).
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self.agent = None;
+        self
+    }
+
+    /// Set the agent (mutually exclusive with model).
+    pub fn with_agent(mut self, agent: impl Into<String>) -> Self {
+        self.agent = Some(agent.into());
+        self.model = None;
+        self
+    }
+
+    // ===== Input =====
+
+    /// Set input from anything that implements `Into<InteractionInput>`.
+    pub fn with_input(mut self, input: impl Into<InteractionInput>) -> Self {
+        self.input = Some(input.into());
+        self
+    }
+
+    /// Set input as plain text.
+    pub fn with_text(mut self, text: impl Into<String>) -> Self {
+        self.input = Some(InteractionInput::Text(text.into()));
+        self
+    }
+
+    /// Set input as a content array (multimodal).
+    pub fn with_content_input(mut self, content: Vec<InteractionContent>) -> Self {
+        self.input = Some(InteractionInput::ContentArray(content));
+        self
+    }
+
+    /// Set input as a step array (stateless multi-turn).
+    pub fn with_step_input(mut self, steps: Vec<Step>) -> Self {
+        self.input = Some(InteractionInput::StepArray(steps));
+        self
+    }
+
+    /// Add image input.
+    pub fn with_image(mut self, data: impl Into<String>, mime_type: ImageMimeType) -> Self {
+        let content = InteractionContent::image(data, mime_type);
+        self.input = match self.input {
+            Some(InteractionInput::ContentArray(mut arr)) => {
+                arr.push(content);
+                Some(InteractionInput::ContentArray(arr))
+            }
+            _ => Some(InteractionInput::ContentArray(vec![content])),
+        };
+        self
+    }
+
+    /// Add image input from a URI.
+    pub fn with_image_uri(mut self, uri: impl Into<String>, mime_type: ImageMimeType) -> Self {
+        let content = InteractionContent::image_uri(uri, mime_type);
+        self.input = match self.input {
+            Some(InteractionInput::ContentArray(mut arr)) => {
+                arr.push(content);
+                Some(InteractionInput::ContentArray(arr))
+            }
+            _ => Some(InteractionInput::ContentArray(vec![content])),
+        };
+        self
+    }
+
+    /// Add audio input.
+    pub fn with_audio(mut self, data: impl Into<String>, mime_type: AudioMimeType) -> Self {
+        let content = InteractionContent::audio(data, mime_type);
+        self.input = match self.input {
+            Some(InteractionInput::ContentArray(mut arr)) => {
+                arr.push(content);
+                Some(InteractionInput::ContentArray(arr))
+            }
+            _ => Some(InteractionInput::ContentArray(vec![content])),
+        };
+        self
+    }
+
+    /// Add video input from a URI.
+    pub fn with_video(mut self, uri: impl Into<String>) -> Self {
+        let content = InteractionContent::video_uri(uri);
+        self.input = match self.input {
+            Some(InteractionInput::ContentArray(mut arr)) => {
+                arr.push(content);
+                Some(InteractionInput::ContentArray(arr))
+            }
+            _ => Some(InteractionInput::ContentArray(vec![content])),
+        };
+        self
+    }
+
+    /// Add document input.
+    pub fn with_document(mut self, data: impl Into<String>, mime_type: DocumentMimeType) -> Self {
+        let content = InteractionContent::document(data, mime_type);
+        self.input = match self.input {
+            Some(InteractionInput::ContentArray(mut arr)) => {
+                arr.push(content);
+                Some(InteractionInput::ContentArray(arr))
+            }
+            _ => Some(InteractionInput::ContentArray(vec![content])),
+        };
+        self
+    }
+
+    // ===== System Instruction =====
+
+    /// Set the system instruction.
+    pub fn with_system_instruction(mut self, instruction: impl Into<String>) -> Self {
+        self.system_instruction = Some(instruction.into());
+        self
+    }
+
+    // ===== Tools =====
+
+    /// Add a tool.
+    pub fn with_tool(mut self, tool: InteractionTool) -> Self {
+        self.tools.push(tool);
+        self
+    }
+
+    /// Add tools.
+    pub fn with_tools(mut self, tools: Vec<InteractionTool>) -> Self {
+        self.tools.extend(tools);
+        self
+    }
+
+    /// Add a function declaration tool.
+    pub fn with_function(
+        mut self,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        self.tools
+            .push(InteractionTool::function(name, description, parameters));
+        self
+    }
+
+    /// Enable Google Search.
+    pub fn with_google_search(mut self) -> Self {
+        self.tools.push(InteractionTool::google_search());
+        self
+    }
+
+    /// Enable code execution.
+    pub fn with_code_execution(mut self) -> Self {
+        self.tools.push(InteractionTool::code_execution());
+        self
+    }
+
+    /// Enable URL context.
+    pub fn with_url_context(mut self) -> Self {
+        self.tools.push(InteractionTool::url_context());
+        self
+    }
+
+    /// Enable Google Maps.
+    pub fn with_google_maps(mut self) -> Self {
+        self.tools.push(InteractionTool::google_maps());
+        self
+    }
+
+    /// Enable file search.
+    pub fn with_file_search(mut self, store_names: Vec<String>) -> Self {
+        self.tools.push(InteractionTool::file_search(store_names));
+        self
+    }
+
+    /// Enable MCP Server.
+    pub fn with_mcp_server(mut self, name: impl Into<String>, url: impl Into<String>) -> Self {
+        self.tools.push(InteractionTool::mcp_server(name, url));
+        self
+    }
+
+    /// Enable computer use.
+    pub fn with_computer_use(mut self, environment: ComputerUseEnvironment) -> Self {
+        self.tools.push(InteractionTool::computer_use(environment));
+        self
+    }
+
+    /// Enable retrieval tool.
+    pub fn with_retrieval(mut self, retrieval_types: Vec<RetrievalType>) -> Self {
+        self.tools.push(InteractionTool::retrieval(retrieval_types));
+        self
+    }
+
+    // ===== Response Format =====
+
+    /// Set the response format.
+    pub fn with_response_format(mut self, format: ResponseFormat) -> Self {
+        self.response_format = Some(format);
+        self
+    }
+
+    /// Set JSON structured output with a schema.
+    pub fn with_json_schema(mut self, schema: serde_json::Value) -> Self {
+        self.response_format = Some(ResponseFormat::json_schema(schema));
+        self
+    }
+
+    // ===== Generation Config =====
+
+    pub fn with_temperature(mut self, temperature: f64) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .temperature = Some(temperature);
+        self
+    }
+
+    pub fn with_top_p(mut self, top_p: f64) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .top_p = Some(top_p);
+        self
+    }
+
+    pub fn with_seed(mut self, seed: i64) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .seed = Some(seed);
+        self
+    }
+
+    pub fn with_stop_sequences(mut self, sequences: Vec<String>) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .stop_sequences = sequences;
+        self
+    }
+
+    pub fn with_max_output_tokens(mut self, tokens: i64) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .max_output_tokens = Some(tokens);
+        self
+    }
+
+    pub fn with_thinking_level(mut self, level: InteractionThinkingLevel) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .thinking_level = Some(level);
+        self
+    }
+
+    pub fn with_thinking_summaries(mut self, summaries: ThinkingSummaries) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .thinking_summaries = Some(summaries);
+        self
+    }
+
+    pub fn with_presence_penalty(mut self, penalty: f64) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .presence_penalty = Some(penalty);
+        self
+    }
+
+    pub fn with_frequency_penalty(mut self, penalty: f64) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .frequency_penalty = Some(penalty);
+        self
+    }
+
+    pub fn with_tool_choice(mut self, choice: ToolChoiceConfig) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .tool_choice = Some(choice);
+        self
+    }
+
+    pub fn with_speech_config(mut self, config: InteractionSpeechConfig) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .speech_config
+            .push(config);
+        self
+    }
+
+    pub fn with_video_config(mut self, config: VideoConfig) -> Self {
+        self.generation_config
+            .get_or_insert_with(Default::default)
+            .video_config = Some(config);
+        self
+    }
+
+    /// Set the full generation config.
+    pub fn with_generation_config(mut self, config: InteractionGenerationConfig) -> Self {
+        self.generation_config = Some(config);
+        self
+    }
+
+    // ===== Agent Config =====
+
+    /// Set the agent config.
+    pub fn with_agent_config(mut self, config: AgentConfig) -> Self {
+        self.agent_config = Some(config);
+        self
+    }
+
+    // ===== Interaction Options =====
+
+    /// Set `previous_interaction_id` for server-side state management.
+    pub fn with_previous_interaction(mut self, id: impl Into<String>) -> Self {
+        self.previous_interaction_id = Some(id.into());
+        self
+    }
+
+    /// Set `store` flag. Use `store(false)` for stateless mode.
+    pub fn with_store(mut self, store: bool) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    /// Enable background execution.
+    pub fn with_background(mut self) -> Self {
+        self.background = true;
+        self
+    }
+
+    /// Set the environment configuration.
+    pub fn with_environment(mut self, env: EnvironmentConfig) -> Self {
+        self.environment = Some(EnvironmentConfigOrString::Config(env));
+        self
+    }
+
+    /// Set the environment by ID (reuse an existing environment).
+    pub fn with_environment_id(mut self, env_id: impl Into<String>) -> Self {
+        self.environment = Some(EnvironmentConfigOrString::Id(env_id.into()));
+        self
+    }
+
+    /// Set cached content.
+    pub fn with_cached_content(mut self, cached_content: impl Into<String>) -> Self {
+        self.cached_content = Some(cached_content.into());
+        self
+    }
+
+    /// Set response modalities.
+    pub fn with_response_modalities(mut self, modalities: Vec<ResponseModality>) -> Self {
+        self.response_modalities = modalities;
+        self
+    }
+
+    /// Set the service tier.
+    pub fn with_service_tier(mut self, tier: ServiceTier) -> Self {
+        self.service_tier = Some(tier);
+        self
+    }
+
+    /// Set the webhook configuration.
+    pub fn with_webhook_config(mut self, config: WebhookConfig) -> Self {
+        self.webhook_config = Some(config);
+        self
+    }
+
+    // ===== Build & Execute =====
+
+    /// Build the request.
+    pub fn build(self) -> Result<CreateInteractionRequest, ClientError> {
+        let input = self.input.ok_or_else(|| ClientError::InvalidResourceName {
+            name: "input is required for interaction".to_string(),
+        })?;
+
+        let model = if self.model.is_none() && self.agent.is_none() {
+            Some(
+                self.client
+                    .model
+                    .as_str()
+                    .trim_start_matches("models/")
+                    .to_string(),
+            )
+        } else {
+            self.model
+        };
+
+        Ok(CreateInteractionRequest {
+            model,
+            agent: self.agent,
+            input,
+            system_instruction: self.system_instruction,
+            tools: self.tools,
+            response_format: self.response_format,
+            stream: None,
+            store: self.store,
+            background: if self.background { Some(true) } else { None },
+            generation_config: self.generation_config,
+            agent_config: self.agent_config,
+            previous_interaction_id: self.previous_interaction_id,
+            environment: self.environment,
+            cached_content: self.cached_content,
+            response_modalities: self.response_modalities,
+            service_tier: self.service_tier,
+            webhook_config: self.webhook_config,
+        })
+    }
+
+    /// Execute the interaction (non-streaming).
+    #[instrument(skip_all, fields(
+        model = self.model.as_deref().unwrap_or(""),
+        agent = self.agent.as_deref().unwrap_or(""),
+        tools.count = self.tools.len(),
+        system.instruction.present = self.system_instruction.is_some(),
+        background = self.background,
+        previous.interaction.present = self.previous_interaction_id.is_some(),
+        status.code,
+        usage.total_tokens,
+    ))]
+    pub async fn execute(self) -> Result<Interaction, ClientError> {
+        let client = self.client.clone();
+        let request = self.build()?;
+        let response = client.create_interaction(request).await?;
+
+        Span::current().record("status.code", response.status.as_ref());
+
+        if let Some(usage) = &response.usage {
+            Span::current().record("usage.total_tokens", usage.total_tokens);
+        }
+
+        Ok(response)
+    }
+
+    /// Execute the interaction (streaming).
+    #[instrument(skip_all, fields(
+        model = self.model.as_deref().unwrap_or(""),
+        agent = self.agent.as_deref().unwrap_or(""),
+        tools.count = self.tools.len(),
+    ))]
+    pub async fn execute_stream(self) -> Result<InteractionStream, ClientError> {
+        let client = self.client.clone();
+        let request = self.build()?;
+        client.create_interaction_stream(request).await
+    }
+}

--- a/src/interactions/handle.rs
+++ b/src/interactions/handle.rs
@@ -1,0 +1,78 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::time::sleep;
+use tracing::instrument;
+
+use crate::client::{Error, GeminiClient};
+use crate::interactions::model::*;
+use crate::interactions::stream::InteractionStream;
+
+/// Handle to an Interaction, usable for get / cancel / delete / poll operations.
+#[derive(Clone)]
+pub struct InteractionHandle {
+    id: String,
+    client: Arc<GeminiClient>,
+}
+
+impl InteractionHandle {
+    pub(crate) fn new(id: String, client: Arc<GeminiClient>) -> Self {
+        Self { id, client }
+    }
+
+    /// Get the interaction ID.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Get the full interaction resource.
+    #[instrument(skip(self))]
+    pub async fn get(&self) -> Result<Interaction, Error> {
+        self.client.get_interaction(&self.id).await
+    }
+
+    /// Get the interaction in streaming mode (can resume from last_event_id).
+    #[instrument(skip(self), fields(last_event_id = last_event_id.unwrap_or("")))]
+    pub async fn get_stream(
+        &self,
+        last_event_id: Option<&str>,
+    ) -> Result<InteractionStream, Error> {
+        self.client
+            .get_interaction_stream(&self.id, last_event_id)
+            .await
+    }
+
+    /// Cancel the interaction (only applicable to background executions).
+    #[instrument(skip(self))]
+    pub async fn cancel(&self) -> Result<Interaction, Error> {
+        self.client.cancel_interaction(&self.id).await
+    }
+
+    /// Delete the interaction.
+    #[instrument(skip(self))]
+    pub async fn delete(&self) -> Result<(), Error> {
+        self.client.delete_interaction(&self.id).await
+    }
+
+    /// Poll until the interaction reaches a terminal state.
+    ///
+    /// Continuously calls `get()` until the status becomes
+    /// completed / failed / cancelled / incomplete / budget_exceeded.
+    /// Suitable for background interactions.
+    #[instrument(skip(self), fields(poll.interval = ?interval))]
+    pub async fn poll_until_completed(&self, interval: Duration) -> Result<Interaction, Error> {
+        loop {
+            let interaction = self.get().await?;
+
+            if interaction.status.is_terminal() {
+                return Ok(interaction);
+            }
+
+            sleep(interval).await;
+        }
+    }
+
+    /// Get this interaction's ID for use as `previous_interaction_id` in the next turn.
+    pub fn as_previous_interaction_id(&self) -> &str {
+        &self.id
+    }
+}

--- a/src/interactions/mod.rs
+++ b/src/interactions/mod.rs
@@ -1,0 +1,189 @@
+//! Interactions API — the modern interface for Gemini models and agents.
+//!
+//! The Interactions API is the simplest and best way to use Gemini models and agents.
+//! It provides a unified interface for all use cases, including single-turn text generation,
+//! multimodal understanding, structured output, tool orchestration, and agentic workflows.
+//!
+//! # Key Advantages
+//!
+//! - Unified interface for models and agents
+//! - Server-side state management (`previous_interaction_id`)
+//! - Observable execution steps
+//! - Background execution
+//! - Higher cache hit rates
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! # use gemini_rust::prelude::*;
+//! # async fn example(gemini: &Gemini) -> Result<(), Box<dyn std::error::Error>> {
+//! let interaction = gemini.create_interaction()
+//!     .with_model("gemini-2.5-flash")
+//!     .with_text("Hello, world!")
+//!     .execute()
+//!     .await?;
+//!
+//! println!("{}", interaction.output_text());
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod builder;
+pub mod handle;
+pub mod model;
+pub mod stream;
+
+pub use builder::InteractionBuilder;
+pub use handle::InteractionHandle;
+pub use model::*;
+pub use stream::{InteractionEvent, InteractionStream, StepDeltaData};
+
+/// Convenience methods on [`Interaction`].
+impl Interaction {
+    /// Get the concatenated final text output.
+    ///
+    /// Extracts text from the last `model_output` step's text content items.
+    pub fn output_text(&self) -> String {
+        self.steps
+            .iter()
+            .rev()
+            .find(|s| matches!(s, Step::ModelOutput { .. }))
+            .and_then(|s| {
+                if let Step::ModelOutput { content, .. } = s {
+                    Some(
+                        content
+                            .iter()
+                            .filter_map(|c| {
+                                if let InteractionContent::Text { text, .. } = c {
+                                    Some(text.clone())
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<_>>()
+                            .join(""),
+                    )
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get all function_call steps.
+    pub fn function_calls(&self) -> Vec<&Step> {
+        self.steps
+            .iter()
+            .filter(|s| matches!(s, Step::FunctionCall { .. }))
+            .collect()
+    }
+
+    /// Get all model_output steps.
+    pub fn model_outputs(&self) -> Vec<&Step> {
+        self.steps
+            .iter()
+            .filter(|s| matches!(s, Step::ModelOutput { .. }))
+            .collect()
+    }
+
+    /// Get all thought steps.
+    pub fn thoughts(&self) -> Vec<&Step> {
+        self.steps
+            .iter()
+            .filter(|s| matches!(s, Step::Thought { .. }))
+            .collect()
+    }
+
+    /// Whether the interaction requires user action (e.g., function calling).
+    pub fn requires_action(&self) -> bool {
+        self.status == InteractionStatus::RequiresAction
+    }
+
+    /// Whether the interaction is completed.
+    pub fn is_completed(&self) -> bool {
+        self.status == InteractionStatus::Completed
+    }
+
+    /// Get the output image (last model-generated image).
+    pub fn output_image(&self) -> Option<&InteractionContent> {
+        self.steps.iter().rev().find_map(|s| {
+            if let Step::ModelOutput { content, .. } = s {
+                content
+                    .iter()
+                    .find(|c| matches!(c, InteractionContent::Image { .. }))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get the output audio (last model-generated audio).
+    pub fn output_audio(&self) -> Option<&InteractionContent> {
+        self.steps.iter().rev().find_map(|s| {
+            if let Step::ModelOutput { content, .. } = s {
+                content
+                    .iter()
+                    .find(|c| matches!(c, InteractionContent::Audio { .. }))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get the output video (last model-generated video).
+    pub fn output_video(&self) -> Option<&InteractionContent> {
+        self.steps.iter().rev().find_map(|s| {
+            if let Step::ModelOutput { content, .. } = s {
+                content
+                    .iter()
+                    .find(|c| matches!(c, InteractionContent::Video { .. }))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get the output document (last model-generated document).
+    pub fn output_document(&self) -> Option<&InteractionContent> {
+        self.steps.iter().rev().find_map(|s| {
+            if let Step::ModelOutput { content, .. } = s {
+                content
+                    .iter()
+                    .find(|c| matches!(c, InteractionContent::Document { .. }))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Get all citation annotations from model outputs.
+    pub fn citations(&self) -> Vec<&Annotation> {
+        self.steps
+            .iter()
+            .filter_map(|s| {
+                if let Step::ModelOutput { content, .. } = s {
+                    Some(content.iter().flat_map(|c| {
+                        if let InteractionContent::Text { annotations, .. } = c {
+                            annotations.iter().collect::<Vec<_>>()
+                        } else {
+                            vec![]
+                        }
+                    }))
+                } else {
+                    None
+                }
+            })
+            .flatten()
+            .collect()
+    }
+
+    /// Get the total token count.
+    pub fn total_tokens(&self) -> Option<i64> {
+        self.usage.as_ref()?.total_tokens
+    }
+
+    /// Get the interaction ID.
+    pub fn id(&self) -> Option<&str> {
+        self.id.as_deref()
+    }
+}

--- a/src/interactions/model.rs
+++ b/src/interactions/model.rs
@@ -1,0 +1,1553 @@
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Content Types (polymorphic, type-tagged)
+// ============================================================================
+
+/// Input content for interactions — type-tagged polymorphic.
+///
+/// Unlike the generateContent API's `Part` enum, Interactions API content
+/// uses a `type` discriminator field for each modality.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InteractionContent {
+    Text {
+        text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        annotations: Vec<Annotation>,
+    },
+    Image {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<ImageMimeType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        resolution: Option<MediaResolution>,
+    },
+    Audio {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<AudioMimeType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        channels: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sample_rate: Option<i32>,
+    },
+    Document {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<DocumentMimeType>,
+    },
+    Video {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<VideoMimeType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        resolution: Option<MediaResolution>,
+    },
+}
+
+impl InteractionContent {
+    /// Create a text content item.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text {
+            text: text.into(),
+            annotations: vec![],
+        }
+    }
+
+    /// Create an image content item from base64 data.
+    pub fn image(data: impl Into<String>, mime_type: ImageMimeType) -> Self {
+        Self::Image {
+            data: Some(data.into()),
+            uri: None,
+            mime_type: Some(mime_type),
+            resolution: None,
+        }
+    }
+
+    /// Create an image content item from a URI.
+    pub fn image_uri(uri: impl Into<String>, mime_type: ImageMimeType) -> Self {
+        Self::Image {
+            data: None,
+            uri: Some(uri.into()),
+            mime_type: Some(mime_type),
+            resolution: None,
+        }
+    }
+
+    /// Create an audio content item from base64 data.
+    pub fn audio(data: impl Into<String>, mime_type: AudioMimeType) -> Self {
+        Self::Audio {
+            data: Some(data.into()),
+            uri: None,
+            mime_type: Some(mime_type),
+            channels: None,
+            sample_rate: None,
+        }
+    }
+
+    /// Create a video content item from a URI.
+    pub fn video_uri(uri: impl Into<String>) -> Self {
+        Self::Video {
+            data: None,
+            uri: Some(uri.into()),
+            mime_type: None,
+            resolution: None,
+        }
+    }
+
+    /// Create a document content item from base64 data.
+    pub fn document(data: impl Into<String>, mime_type: DocumentMimeType) -> Self {
+        Self::Document {
+            data: Some(data.into()),
+            uri: None,
+            mime_type: Some(mime_type),
+        }
+    }
+}
+
+// ============================================================================
+// Annotation Types
+// ============================================================================
+
+/// Citation annotation — type-tagged polymorphic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Annotation {
+    UrlCitation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        start_index: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_index: Option<i64>,
+    },
+    FileCitation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        document_uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        file_name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        custom_metadata: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        page_number: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        media_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        start_index: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_index: Option<i64>,
+    },
+    PlaceCitation {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        place_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        review_snippets: Option<ReviewSnippet>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        start_index: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        end_index: Option<i64>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ReviewSnippet {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_id: Option<String>,
+}
+
+// ============================================================================
+// Step Types (the core of Interactions API)
+// ============================================================================
+
+/// A single step in an interaction — type-tagged polymorphic.
+///
+/// Each step represents a typed action in the interaction history:
+/// user input, model output, thoughts, function calls, tool invocations, etc.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Step {
+    UserInput {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        content: Vec<InteractionContent>,
+    },
+
+    ModelOutput {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        content: Vec<InteractionContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<Status>,
+    },
+
+    Thought {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        summary: Vec<ThoughtSummaryContent>,
+    },
+
+    FunctionCall {
+        name: String,
+        arguments: serde_json::Value,
+        id: String,
+    },
+
+    FunctionResult {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        call_id: String,
+        result: StepResult,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+    },
+
+    CodeExecutionCall {
+        arguments: CodeExecutionCallArguments,
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    CodeExecutionResult {
+        result: String,
+        call_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    UrlContextCall {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+        arguments: UrlContextCallArguments,
+    },
+
+    UrlContextResult {
+        result: UrlContextResultData,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+        call_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    GoogleSearchCall {
+        arguments: GoogleSearchCallArguments,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        search_type: Option<GoogleSearchType>,
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    GoogleSearchResult {
+        result: GoogleSearchResultItem,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+        call_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    GoogleMapsCall {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        arguments: Option<GoogleMapsCallArguments>,
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    GoogleMapsResult {
+        result: GoogleMapsResultItem,
+        call_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    FileSearchCall {
+        id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    FileSearchResult {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        citations: Vec<Annotation>,
+        call_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+
+    McpServerToolCall {
+        name: String,
+        server_name: String,
+        arguments: serde_json::Value,
+        id: String,
+    },
+
+    McpServerToolResult {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        server_name: Option<String>,
+        call_id: String,
+        result: StepResult,
+    },
+}
+
+// ============================================================================
+// Step Sub-types
+// ============================================================================
+
+/// Function result can be a content array, JSON object, or string.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum StepResult {
+    ContentArray(Vec<StepResultContent>),
+    Object(serde_json::Value),
+    String(String),
+}
+
+impl StepResult {
+    pub fn from_string(s: impl Into<String>) -> Self {
+        Self::String(s.into())
+    }
+
+    pub fn from_json(value: serde_json::Value) -> Self {
+        Self::Object(value)
+    }
+}
+
+/// Content items allowed in step results (text or image only).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StepResultContent {
+    Text {
+        text: String,
+    },
+    Image {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        data: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<ImageMimeType>,
+    },
+}
+
+/// Thought summary content — polymorphic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ThoughtSummaryContent {
+    Text { text: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodeExecutionCallArguments {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<CodeLanguage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct UrlContextCallArguments {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoogleSearchCallArguments {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub queries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoogleMapsCallArguments {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub queries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoogleSearchResultItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub search_suggestions: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoogleMapsResultItem {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub places: Option<GoogleMapsResultPlaces>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct GoogleMapsResultPlaces {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub place_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_snippets: Option<ReviewSnippet>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub widget_context_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct UrlContextResultData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<UrlContextStatus>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Status {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub details: Vec<serde_json::Value>,
+}
+
+// ============================================================================
+// Interaction Resource
+// ============================================================================
+
+/// Interaction resource — represents a complete interaction.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct Interaction {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+
+    #[serde(default)]
+    pub status: InteractionStatus,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub steps: Vec<Step>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<InteractionUsage>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<InteractionTool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_interaction_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_modalities: Option<Vec<ResponseModality>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_content: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_config: Option<AgentConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<InteractionError>,
+}
+
+/// Interaction status.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionStatus {
+    #[default]
+    InProgress,
+    RequiresAction,
+    Completed,
+    Failed,
+    Cancelled,
+    Incomplete,
+    BudgetExceeded,
+}
+
+impl InteractionStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Completed
+                | Self::Failed
+                | Self::Cancelled
+                | Self::Incomplete
+                | Self::BudgetExceeded
+        )
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(self, Self::InProgress | Self::RequiresAction)
+    }
+}
+
+impl AsRef<str> for InteractionStatus {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::InProgress => "in_progress",
+            Self::RequiresAction => "requires_action",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Incomplete => "incomplete",
+            Self::BudgetExceeded => "budget_exceeded",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct InteractionError {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+}
+
+// ============================================================================
+// Tool Types
+// ============================================================================
+
+/// Tool declaration — type-tagged polymorphic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InteractionTool {
+    Function {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        parameters: Option<serde_json::Value>,
+    },
+
+    CodeExecution,
+
+    UrlContext,
+
+    ComputerUse {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        environment: Option<ComputerUseEnvironment>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        excluded_predefined_functions: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        enable_prompt_injection_detection: Option<bool>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        disabled_safety_policies: Vec<ComputerUseSafetyPolicy>,
+    },
+
+    McpServer {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        url: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        headers: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        allowed_tools: Option<AllowedTools>,
+    },
+
+    GoogleSearch {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        search_types: Vec<GoogleSearchType>,
+    },
+
+    FileSearch {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        file_search_store_names: Vec<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        top_k: Option<i64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata_filter: Option<String>,
+    },
+
+    GoogleMaps {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        enable_widget: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        latitude: Option<f64>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        longitude: Option<f64>,
+    },
+
+    Retrieval {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        retrieval_types: Vec<RetrievalType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        exa_ai_search_config: Option<ExaAISearchConfig>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        parallel_ai_search_config: Option<ParallelAISearchConfig>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        rag_store_config: Option<RagStoreConfig>,
+    },
+}
+
+impl InteractionTool {
+    /// Create a function tool.
+    pub fn function(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: serde_json::Value,
+    ) -> Self {
+        Self::Function {
+            name: Some(name.into()),
+            description: Some(description.into()),
+            parameters: Some(parameters),
+        }
+    }
+
+    /// Create a Google Search tool.
+    pub fn google_search() -> Self {
+        Self::GoogleSearch {
+            search_types: vec![GoogleSearchType::WebSearch],
+        }
+    }
+
+    /// Create a code execution tool.
+    pub fn code_execution() -> Self {
+        Self::CodeExecution
+    }
+
+    /// Create a URL context tool.
+    pub fn url_context() -> Self {
+        Self::UrlContext
+    }
+
+    /// Create a Google Maps tool.
+    pub fn google_maps() -> Self {
+        Self::GoogleMaps {
+            enable_widget: None,
+            latitude: None,
+            longitude: None,
+        }
+    }
+
+    /// Create a file search tool.
+    pub fn file_search(store_names: Vec<String>) -> Self {
+        Self::FileSearch {
+            file_search_store_names: store_names,
+            top_k: None,
+            metadata_filter: None,
+        }
+    }
+
+    /// Create an MCP Server tool.
+    pub fn mcp_server(name: impl Into<String>, url: impl Into<String>) -> Self {
+        Self::McpServer {
+            name: Some(name.into()),
+            url: Some(url.into()),
+            headers: None,
+            allowed_tools: None,
+        }
+    }
+
+    /// Create a computer use tool.
+    pub fn computer_use(environment: ComputerUseEnvironment) -> Self {
+        Self::ComputerUse {
+            environment: Some(environment),
+            excluded_predefined_functions: vec![],
+            enable_prompt_injection_detection: None,
+            disabled_safety_policies: vec![],
+        }
+    }
+
+    /// Create a retrieval tool.
+    pub fn retrieval(retrieval_types: Vec<RetrievalType>) -> Self {
+        Self::Retrieval {
+            retrieval_types,
+            exa_ai_search_config: None,
+            parallel_ai_search_config: None,
+            rag_store_config: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AllowedTools {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ToolChoiceMode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ExaAISearchConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_config: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct ParallelAISearchConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_config: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RagStoreConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rag_resources: Option<RagResource>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RagResource {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rag_corpus: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rag_file_ids: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rag_retrieval_config: Option<RagRetrievalConfig>,
+}
+
+/// Retrieval configuration for RAG queries.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RagRetrievalConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hybrid_search: Option<HybridSearch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<RagFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ranking: Option<Ranking>,
+}
+
+/// Hybrid search configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct HybridSearch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alpha: Option<f64>,
+}
+
+/// Filter configuration for RAG retrieval.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct RagFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_distance_threshold: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vector_similarity_threshold: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata_filter: Option<String>,
+}
+
+/// Ranking and reranking configuration.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct Ranking {
+    #[serde(flatten)]
+    pub config: Option<serde_json::Value>,
+}
+
+// ============================================================================
+// Response Format Types
+// ============================================================================
+
+/// Response format configuration — type-tagged polymorphic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResponseFormat {
+    Text {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<TextMimeType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        schema: Option<serde_json::Value>,
+    },
+    Audio {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<AudioOutputMimeType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        delivery: Option<DeliveryMode>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sample_rate: Option<i32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        bit_rate: Option<i32>,
+    },
+    Image {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        mime_type: Option<ImageOutputMimeType>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        delivery: Option<DeliveryMode>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        aspect_ratio: Option<AspectRatio>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        image_size: Option<ImageSize>,
+    },
+    Video {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        delivery: Option<DeliveryMode>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        gcs_uri: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        aspect_ratio: Option<VideoAspectRatio>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        duration: Option<String>,
+    },
+}
+
+impl ResponseFormat {
+    /// JSON structured output with a schema.
+    pub fn json_schema(schema: serde_json::Value) -> Self {
+        Self::Text {
+            mime_type: Some(TextMimeType::ApplicationJson),
+            schema: Some(schema),
+        }
+    }
+
+    /// Plain text output.
+    pub fn text() -> Self {
+        Self::Text {
+            mime_type: Some(TextMimeType::TextPlain),
+            schema: None,
+        }
+    }
+}
+
+// ============================================================================
+// Generation Config (Interactions version)
+// ============================================================================
+
+/// Model interaction configuration (mutually exclusive with agent_config).
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct InteractionGenerationConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub stop_sequences: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_level: Option<InteractionThinkingLevel>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking_summaries: Option<ThinkingSummaries>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_output_tokens: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub speech_config: Vec<InteractionSpeechConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub video_config: Option<VideoConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoiceConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionThinkingLevel {
+    Minimal,
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ThinkingSummaries {
+    Auto,
+    None,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct InteractionSpeechConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub voice: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct VideoConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<VideoTask>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolChoiceConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_tools: Option<AllowedTools>,
+}
+
+// ============================================================================
+// Usage Types
+// ============================================================================
+
+/// Token usage statistics.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct InteractionUsage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_input_tokens: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_tokens_by_modality: Vec<ModalityTokens>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_cached_tokens: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub cached_tokens_by_modality: Vec<ModalityTokens>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_output_tokens: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_tokens_by_modality: Vec<ModalityTokens>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_tool_use_tokens: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_use_tokens_by_modality: Vec<ModalityTokens>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_thought_tokens: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_tokens: Option<i64>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub grounding_tool_count: Vec<GroundingToolCount>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ModalityTokens {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modality: Option<ResponseModality>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokens: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GroundingToolCount {
+    #[serde(rename = "type")]
+    pub grounding_type: Option<GroundingType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<i64>,
+}
+
+// ============================================================================
+// Agent Config Types
+// ============================================================================
+
+/// Agent configuration (mutually exclusive with generation_config).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum AgentConfig {
+    Dynamic,
+
+    DeepResearch {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thinking_summaries: Option<ThinkingSummaries>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        visualization: Option<Visualization>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        collaborative_planning: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        enable_bigquery_tool: Option<bool>,
+    },
+}
+
+// ============================================================================
+// Enum Types
+// ============================================================================
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResponseModality {
+    Text,
+    Image,
+    Audio,
+    Video,
+    Document,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ServiceTier {
+    Flex,
+    Standard,
+    Priority,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum DeliveryMode {
+    Inline,
+    Uri,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum MediaResolution {
+    Low,
+    Medium,
+    High,
+    UltraHigh,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ImageMimeType {
+    #[serde(rename = "image/png")]
+    Png,
+    #[serde(rename = "image/jpeg")]
+    Jpeg,
+    #[serde(rename = "image/webp")]
+    Webp,
+    #[serde(rename = "image/heic")]
+    Heic,
+    #[serde(rename = "image/heif")]
+    Heif,
+    #[serde(rename = "image/gif")]
+    Gif,
+    #[serde(rename = "image/bmp")]
+    Bmp,
+    #[serde(rename = "image/tiff")]
+    Tiff,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AudioMimeType {
+    #[serde(rename = "audio/wav")]
+    Wav,
+    #[serde(rename = "audio/mp3")]
+    Mp3,
+    #[serde(rename = "audio/aac")]
+    Aac,
+    #[serde(rename = "audio/flac")]
+    Flac,
+    #[serde(rename = "audio/ogg")]
+    Ogg,
+    #[serde(rename = "audio/ogg_opus")]
+    OggOpus,
+    #[serde(rename = "audio/m4a")]
+    M4a,
+    #[serde(rename = "audio/opus")]
+    Opus,
+    #[serde(rename = "audio/pcm")]
+    Pcm,
+    #[serde(rename = "audio/l16")]
+    L16,
+    #[serde(rename = "audio/mulaw")]
+    Mulaw,
+    #[serde(rename = "audio/alaw")]
+    Alaw,
+    #[serde(rename = "audio/amr")]
+    Amr,
+    #[serde(rename = "audio/aiff")]
+    Aiff,
+    #[serde(rename = "audio/mpeg")]
+    Mpeg,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum VideoMimeType {
+    #[serde(rename = "video/mp4")]
+    Mp4,
+    #[serde(rename = "video/webm")]
+    Webm,
+    #[serde(rename = "video/quicktime")]
+    Quicktime,
+    #[serde(rename = "video/mpeg")]
+    Mpeg,
+    #[serde(rename = "video/x-ms-wmv")]
+    Wmv,
+    #[serde(rename = "video/x-flv")]
+    Flv,
+    #[serde(rename = "video/3gpp")]
+    ThreeGpp,
+    #[serde(rename = "video/avi")]
+    Avi,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum DocumentMimeType {
+    #[serde(rename = "application/pdf")]
+    Pdf,
+    #[serde(rename = "text/plain")]
+    TextPlain,
+    #[serde(rename = "text/html")]
+    TextHtml,
+    #[serde(rename = "text/css")]
+    TextCss,
+    #[serde(rename = "text/csv")]
+    TextCsv,
+    #[serde(rename = "text/javascript")]
+    TextJavascript,
+    #[serde(rename = "text/x-typescript")]
+    TextXTypescript,
+    #[serde(rename = "application/json")]
+    ApplicationJson,
+    #[serde(rename = "application/rtf")]
+    Rtf,
+    #[serde(rename = "application/vnd.openxmlformats-officedocument.wordprocessingml.document")]
+    Docx,
+    #[serde(rename = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")]
+    Xlsx,
+    #[serde(rename = "application/vnd.openxmlformats-officedocument.presentationml.presentation")]
+    Pptx,
+    #[serde(rename = "application/vnd.ms-excel")]
+    Xls,
+    #[serde(rename = "application/vnd.ms-powerpoint")]
+    Ppt,
+    #[serde(rename = "application/msword")]
+    Doc,
+    #[serde(rename = "text/markdown")]
+    TextMarkdown,
+    #[serde(rename = "text/x-python")]
+    TextXPython,
+    #[serde(rename = "application/x-java-source")]
+    ApplicationXJavaSource,
+    #[serde(rename = "application/x-sh")]
+    ApplicationXSh,
+    #[serde(rename = "application/typescript")]
+    ApplicationTypescript,
+    #[serde(rename = "application/x-typescript")]
+    ApplicationXTypescript,
+    #[serde(rename = "application/javascript")]
+    ApplicationJavascript,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum TextMimeType {
+    #[serde(rename = "text/plain")]
+    TextPlain,
+    #[serde(rename = "application/json")]
+    ApplicationJson,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AudioOutputMimeType {
+    #[serde(rename = "audio/mp3")]
+    Mp3,
+    #[serde(rename = "audio/ogg_opus")]
+    OggOpus,
+    #[serde(rename = "audio/l16")]
+    L16,
+    #[serde(rename = "audio/wav")]
+    Wav,
+    #[serde(rename = "audio/alaw")]
+    Alaw,
+    #[serde(rename = "audio/mulaw")]
+    Mulaw,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ImageOutputMimeType {
+    #[serde(rename = "image/jpeg")]
+    Jpeg,
+    #[serde(rename = "image/png")]
+    Png,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AspectRatio {
+    #[serde(rename = "1:1")]
+    R1x1,
+    #[serde(rename = "2:3")]
+    R2x3,
+    #[serde(rename = "3:2")]
+    R3x2,
+    #[serde(rename = "3:4")]
+    R3x4,
+    #[serde(rename = "4:3")]
+    R4x3,
+    #[serde(rename = "4:5")]
+    R4x5,
+    #[serde(rename = "5:4")]
+    R5x4,
+    #[serde(rename = "9:16")]
+    R9x16,
+    #[serde(rename = "16:9")]
+    R16x9,
+    #[serde(rename = "21:9")]
+    R21x9,
+    #[serde(rename = "1:8")]
+    R1x8,
+    #[serde(rename = "8:1")]
+    R8x1,
+    #[serde(rename = "1:4")]
+    R1x4,
+    #[serde(rename = "4:1")]
+    R4x1,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ImageSize {
+    #[serde(rename = "512")]
+    S512,
+    #[serde(rename = "1K")]
+    S1k,
+    #[serde(rename = "2K")]
+    S2k,
+    #[serde(rename = "4K")]
+    S4k,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum VideoAspectRatio {
+    #[serde(rename = "16:9")]
+    R16x9,
+    #[serde(rename = "9:16")]
+    R9x16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum VideoTask {
+    TextToVideo,
+    ImageToVideo,
+    ReferenceToVideo,
+    Edit,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeLanguage {
+    Python,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoogleSearchType {
+    WebSearch,
+    ImageSearch,
+    EnterpriseWebSearch,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum RetrievalType {
+    RagStore,
+    ExaAiSearch,
+    ParallelAiSearch,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputerUseEnvironment {
+    Browser,
+    Mobile,
+    Desktop,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ComputerUseSafetyPolicy {
+    DangerousContent,
+    Harassment,
+    HateSpeech,
+    SexuallyExplicit,
+    CivilIntegrity,
+    Csam,
+    TributeSpeech,
+    Unspecified,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum UrlContextStatus {
+    Success,
+    Error,
+    Paywall,
+    Unsafe,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolChoiceMode {
+    Auto,
+    Any,
+    None,
+    Validated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum Visualization {
+    Off,
+    Auto,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum GroundingType {
+    GoogleSearch,
+    GoogleMaps,
+    Retrieval,
+}
+
+// ============================================================================
+// Webhook Config
+// ============================================================================
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct WebhookConfig {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub uris: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_metadata: Option<serde_json::Value>,
+}
+
+// ============================================================================
+// Environment Config
+// ============================================================================
+
+/// Environment configuration — can be a full config object or just an ID string.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum EnvironmentConfigOrString {
+    Config(EnvironmentConfig),
+    Id(String),
+}
+
+/// Environment configuration — type-tagged polymorphic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EnvironmentConfig {
+    Remote {
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        sources: Vec<EnvironmentSource>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        environment_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        network: Option<EnvironmentNetwork>,
+    },
+}
+
+/// Environment source — type-tagged polymorphic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EnvironmentSource {
+    Gcs {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        target: Option<String>,
+    },
+    Inline {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        target: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        encoding: Option<String>,
+    },
+    Repository {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        target: Option<String>,
+    },
+    SkillRegistry {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        source: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        target: Option<String>,
+    },
+}
+
+/// Network configuration — can be an allowlist object or "disabled" string.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum EnvironmentNetwork {
+    Allowlist(EnvironmentNetworkEgressAllowlist),
+    Disabled(String),
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct EnvironmentNetworkEgressAllowlist {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub allowlist: Vec<AllowlistEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct AllowlistEntry {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transform: Vec<serde_json::Value>,
+}
+
+// ============================================================================
+// CreateInteractionRequest
+// ============================================================================
+
+/// Request body for creating an interaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateInteractionRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+
+    pub input: InteractionInput,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_instruction: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<InteractionTool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub store: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_config: Option<InteractionGenerationConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_config: Option<AgentConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_interaction_id: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub environment: Option<EnvironmentConfigOrString>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cached_content: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub response_modalities: Vec<ResponseModality>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<ServiceTier>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub webhook_config: Option<WebhookConfig>,
+}
+
+/// Input can be a string, single Content, Content array, or Step array.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum InteractionInput {
+    Text(String),
+    Content(InteractionContent),
+    ContentArray(Vec<InteractionContent>),
+    StepArray(Vec<Step>),
+}
+
+impl InteractionInput {
+    /// Create text input.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text(text.into())
+    }
+
+    /// Create content array input.
+    pub fn content_array(content: Vec<InteractionContent>) -> Self {
+        Self::ContentArray(content)
+    }
+
+    /// Create step array input.
+    pub fn step_array(steps: Vec<Step>) -> Self {
+        Self::StepArray(steps)
+    }
+}
+
+impl From<String> for InteractionInput {
+    fn from(s: String) -> Self {
+        Self::Text(s)
+    }
+}
+
+impl From<&str> for InteractionInput {
+    fn from(s: &str) -> Self {
+        Self::Text(s.to_string())
+    }
+}
+
+impl From<Vec<InteractionContent>> for InteractionInput {
+    fn from(c: Vec<InteractionContent>) -> Self {
+        Self::ContentArray(c)
+    }
+}
+
+impl From<Vec<Step>> for InteractionInput {
+    fn from(s: Vec<Step>) -> Self {
+        Self::StepArray(s)
+    }
+}

--- a/src/interactions/stream.rs
+++ b/src/interactions/stream.rs
@@ -1,0 +1,269 @@
+use std::pin::Pin;
+
+use futures::Stream;
+use serde::Deserialize;
+
+use crate::client::Error;
+use crate::interactions::model::*;
+
+/// Interaction stream — yields `InteractionEvent` items.
+pub type InteractionStream = Pin<Box<dyn Stream<Item = Result<InteractionEvent, Error>> + Send>>;
+
+/// SSE event from the Interactions API stream.
+///
+/// Each event represents a lifecycle event in the interaction:
+/// interaction creation/completion, step start/delta/stop, status updates, or errors.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "event_type")]
+pub enum InteractionEvent {
+    #[serde(rename = "interaction.created")]
+    InteractionCreated {
+        interaction: StreamInteraction,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StreamMetadata>,
+    },
+
+    #[serde(rename = "interaction.completed")]
+    InteractionCompleted {
+        interaction: StreamInteraction,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StreamMetadata>,
+    },
+
+    #[serde(rename = "interaction.status_update")]
+    InteractionStatusUpdate {
+        interaction_id: String,
+        status: InteractionStatus,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StreamMetadata>,
+    },
+
+    #[serde(rename = "error")]
+    Error {
+        error: InteractionError,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StreamMetadata>,
+    },
+
+    #[serde(rename = "step.start")]
+    StepStart {
+        index: usize,
+        step: Step,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StepDeltaMetadata>,
+    },
+
+    #[serde(rename = "step.delta")]
+    StepDelta {
+        index: usize,
+        delta: StepDeltaData,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StepDeltaMetadata>,
+    },
+
+    #[serde(rename = "step.stop")]
+    StepStop {
+        index: usize,
+        #[serde(default)]
+        usage: Option<InteractionUsage>,
+        #[serde(default)]
+        step_usage: Option<InteractionUsage>,
+        #[serde(default)]
+        event_id: Option<String>,
+        #[serde(default)]
+        metadata: Option<StreamMetadata>,
+    },
+}
+
+/// Partial Interaction resource in stream events (may omit some fields).
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StreamInteraction {
+    pub id: Option<String>,
+    pub object: Option<String>,
+    pub model: Option<String>,
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub status: InteractionStatus,
+    pub created: Option<String>,
+    pub updated: Option<String>,
+    pub service_tier: Option<ServiceTier>,
+    pub usage: Option<InteractionUsage>,
+    #[serde(default)]
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StreamMetadata {
+    #[serde(default)]
+    pub total_usage: Option<InteractionUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StepDeltaMetadata {
+    #[serde(default)]
+    pub total_usage: Option<InteractionUsage>,
+}
+
+/// Step delta data — type-tagged polymorphic.
+///
+/// Represents incremental updates to a step during streaming.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StepDeltaData {
+    Text {
+        text: String,
+    },
+
+    Image {
+        #[serde(default)]
+        data: Option<String>,
+        #[serde(default)]
+        uri: Option<String>,
+        #[serde(default)]
+        mime_type: Option<ImageMimeType>,
+        #[serde(default)]
+        resolution: Option<MediaResolution>,
+    },
+
+    Audio {
+        #[serde(default)]
+        data: Option<String>,
+        #[serde(default)]
+        uri: Option<String>,
+        #[serde(default)]
+        mime_type: Option<AudioMimeType>,
+        #[serde(default)]
+        sample_rate: Option<i32>,
+        #[serde(default)]
+        channels: Option<i32>,
+    },
+
+    Document {
+        #[serde(default)]
+        data: Option<String>,
+        #[serde(default)]
+        uri: Option<String>,
+        #[serde(default)]
+        mime_type: Option<DocumentMimeType>,
+    },
+
+    Video {
+        #[serde(default)]
+        data: Option<String>,
+        #[serde(default)]
+        uri: Option<String>,
+        #[serde(default)]
+        mime_type: Option<VideoMimeType>,
+        #[serde(default)]
+        resolution: Option<MediaResolution>,
+    },
+
+    ThoughtSummary {
+        #[serde(default)]
+        content: Option<InteractionContent>,
+    },
+
+    ThoughtSignature {
+        #[serde(default)]
+        signature: Option<String>,
+    },
+
+    TextAnnotationDelta {
+        annotations: Vec<Annotation>,
+    },
+
+    ArgumentsDelta {
+        #[serde(default)]
+        arguments: Option<String>,
+    },
+
+    CodeExecutionCall {
+        arguments: CodeExecutionCallArguments,
+    },
+
+    CodeExecutionResult {
+        result: String,
+        #[serde(default)]
+        is_error: Option<bool>,
+    },
+
+    UrlContextCall {
+        arguments: UrlContextCallArguments,
+    },
+
+    UrlContextResult {
+        result: UrlContextResultData,
+        #[serde(default)]
+        is_error: Option<bool>,
+    },
+
+    GoogleSearchCall {
+        arguments: GoogleSearchCallArguments,
+    },
+
+    GoogleSearchResult {
+        result: GoogleSearchResultItem,
+        #[serde(default)]
+        is_error: Option<bool>,
+    },
+
+    GoogleMapsCall {
+        #[serde(default)]
+        arguments: Option<GoogleMapsCallArguments>,
+    },
+
+    GoogleMapsResult {
+        #[serde(default)]
+        result: Option<GoogleMapsResultItem>,
+    },
+
+    FileSearchCall,
+
+    FileSearchResult {
+        #[serde(default)]
+        result: Option<FileSearchResultData>,
+    },
+
+    McpServerToolCall {
+        name: String,
+        server_name: String,
+        arguments: serde_json::Value,
+    },
+
+    McpServerToolResult {
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        server_name: Option<String>,
+        result: StepResult,
+    },
+
+    FunctionResult {
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(default)]
+        is_error: Option<bool>,
+        call_id: String,
+        result: StepResult,
+    },
+}
+
+/// File search result data (for streaming deltas).
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct FileSearchResultData {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub citations: Vec<Annotation>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ pub mod files;
 /// Content generation including text, images, and audio
 pub mod generation;
 
+/// Interactions API — the modern interface for Gemini models and agents
+pub mod interactions;
+
 /// Content moderation and safety settings
 pub mod safety;
 
@@ -83,7 +86,7 @@ pub use models::{Blob, Content, FileData, Message, Modality, Part, Role};
 
 // ========== Content Generation ==========
 // Types for generating text, images, and audio content
-
+#[allow(deprecated)]
 pub use generation::{
     builder::ContentBuilder, model::BlockReason, model::Candidate, model::CitationMetadata,
     model::CitationSource, model::CountTokensResponse, model::FinishReason,
@@ -94,6 +97,14 @@ pub use generation::{
     model::PromptFeedback, model::PromptTokenDetails, model::SpeakerVoiceConfig,
     model::SpeechConfig, model::ThinkingConfig, model::ThinkingLevel, model::UsageMetadata,
     model::VoiceConfig, model::WebGroundingChunk,
+};
+
+// ========== Interactions API ==========
+// Types for the Interactions API — the modern interface for Gemini models and agents
+
+pub use interactions::model::*;
+pub use interactions::{
+    InteractionBuilder, InteractionEvent, InteractionHandle, InteractionStream, StepDeltaData,
 };
 
 // ========== Text Embeddings ==========

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,15 +15,18 @@
 pub use crate::{ClientError, Gemini, Model};
 
 // Builders for creating requests
+#[allow(deprecated)]
 pub use crate::{ContentBuilder, EmbedBuilder};
 
 // Core data types for messages and content
 pub use crate::{Content, FileData, Message, Role};
 
 // Main response types
+#[allow(deprecated)]
 pub use crate::{ContentEmbeddingResponse, CountTokensResponse, GenerationResponse};
 
 // Configuration types
+#[allow(deprecated)]
 pub use crate::{GenerationConfig, TaskType};
 
 // Safety settings
@@ -39,4 +42,18 @@ pub use crate::{Batch, FileHandle};
 pub use crate::{
     ChunkingConfig, CustomMetadata, CustomMetadataValue, DocumentHandle, FileSearchStoreHandle,
     OperationHandle, WhiteSpaceConfig,
+};
+
+// Interactions API — the modern way to use Gemini
+pub use crate::{
+    AgentConfig, AllowedTools, Annotation, AspectRatio, AudioMimeType, AudioOutputMimeType,
+    CodeExecutionCallArguments, CodeLanguage, DeliveryMode, DocumentMimeType, EnvironmentConfig,
+    EnvironmentConfigOrString, EnvironmentSource, GoogleSearchType, ImageMimeType,
+    ImageOutputMimeType, ImageSize, Interaction, InteractionBuilder, InteractionContent,
+    InteractionEvent, InteractionGenerationConfig, InteractionHandle, InteractionInput,
+    InteractionSpeechConfig, InteractionStatus, InteractionStream, InteractionThinkingLevel,
+    InteractionTool, InteractionUsage, MediaResolution, ResponseFormat, ResponseModality,
+    ServiceTier, Step, StepDeltaData, StepResult, TextMimeType, ThinkingSummaries,
+    ThoughtSummaryContent, ToolChoiceConfig, VideoAspectRatio, VideoConfig, VideoMimeType,
+    Visualization, WebhookConfig,
 };


### PR DESCRIPTION
…precation marks

Implement the Interactions API as the modern interface for Gemini models and agents, alongside the existing generateContent API (now deprecated).

Core implementation (src/interactions/):
- model.rs: Interaction, Step (18 variants), InteractionContent, InteractionTool (9 variants), ResponseFormat, InteractionGenerationConfig, InteractionUsage, AgentConfig, CreateInteractionRequest, 40+ supporting enums/structs
- builder.rs: InteractionBuilder with 40+ fluent methods
- stream.rs: InteractionEvent (7 variants), StepDeltaData (22 variants), InteractionStream type alias
- handle.rs: InteractionHandle (get/cancel/delete/poll_until_completed)
- mod.rs: Convenience methods on Interaction (output_text, function_calls, citations, etc.)

Client extensions (src/client.rs):
- GeminiClient: create/get/cancel/delete interaction (streaming + non-streaming)
- Gemini: create_interaction(), interaction(), get_interaction()

Deprecation marks:
- ContentBuilder, GenerateContentRequest, GenerationResponse, GenerationConfig, Gemini::generate_content() marked #[deprecated]
- Internal #[allow(deprecated)] added to generation, batch, and client modules

18 new examples covering: basic, streaming, multi-turn, multimodal, structured output, function calling, thinking, google search, google maps, code execution, url context, file search, image gen, TTS, background execution, deep research agent, advanced config, error handling, custom client, and tracing.

README.md updated with Interactions API quick start section. Migration plan documented in interactions-api/migration-plan.md.